### PR TITLE
Add test for deleteRoute method

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "grunt-contrib-copy": "^0.7.0",
     "grunt-contrib-cssmin": "^0.12.0",
     "grunt-contrib-htmlmin": "^0.4.0",
-    "grunt-contrib-imagemin": "^0.9.2",
+    "grunt-contrib-imagemin": "^1.0.0",
     "grunt-contrib-jshint": "^0.11.0",
     "grunt-contrib-uglify": "^0.7.0",
     "grunt-contrib-watch": "^0.6.1",

--- a/test/spec/services/utilsroutesvc.js
+++ b/test/spec/services/utilsroutesvc.js
@@ -7,11 +7,55 @@ describe('Service: utilsRouteSvc', function() {
 
   // instantiate service
   var utilsRouteSvc, utilsChartSvc
-  beforeEach(inject(function(_utilsRouteSvc_, _utilsChartSvc_) {
+  beforeEach(inject(function(_utilsRouteSvc_, _utilsChartSvc_, _routesSvc_, $q,
+  _notificationService_, $rootScope) {
     utilsRouteSvc = _utilsRouteSvc_
     utilsChartSvc = _utilsChartSvc_
+
     spyOn(utilsChartSvc, 'typeColor').and.returnValue('green')
   }))
+
+  describe('#deleteRoute method', function() {
+    var mockRoute, notificationService, scope, deferred, routesSvc
+
+    beforeEach(inject(function(_routesSvc_, $q, _notificationService_,
+    $rootScope) {
+      mockRoute= { id: 1, name: 'test' }
+      notificationService = _notificationService_
+      routesSvc = _routesSvc_
+
+      scope = $rootScope.$new()
+      deferred = $q.defer()
+
+      spyOn(routesSvc, 'deleteRoute').and.returnValue(deferred.promise)
+      spyOn(notificationService, 'success')
+      spyOn(notificationService, 'info')
+      spyOn(utilsRouteSvc, 'createRouteSync').and.callThrough()
+    }))
+
+    it('should call delete Route from routeSvc', function() {
+      utilsRouteSvc.deleteRoute(mockRoute)
+
+      expect(routesSvc.deleteRoute).toHaveBeenCalledWith(mockRoute.id)
+    })
+
+    it('should notify user in case of success', function() {
+      utilsRouteSvc.deleteRoute(mockRoute)
+      deferred.resolve()
+      scope.$digest()
+
+      expect(notificationService.success).toHaveBeenCalled()
+    })
+
+    it('should notify user in case of error based on second param', function() {
+      utilsRouteSvc.deleteRoute(mockRoute)
+      deferred.reject()
+      scope.$digest()
+
+      expect(utilsRouteSvc.createRouteSync).toHaveBeenCalledWith('delete', mockRoute)
+      expect(notificationService.info).toHaveBeenCalled()
+    })
+  })
 
   it('should #getTypeColor', function() {
     var route = {type: 'test'}


### PR DESCRIPTION
**Problem**
Test coverage is failing as the threshold for failure is set to 80%

**Solution**
Increase coverage on the `utilsroutesvc` service for the `deleteRoute`
method.