### PR TITLE
Add documentation generated with jsdoc

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -17,7 +17,8 @@ module.exports = function(grunt) {
     useminPrepare: 'grunt-usemin',
     ngtemplates: 'grunt-angular-templates',
     cdnify: 'grunt-google-cdn',
-    coveralls: 'grunt-karma-coveralls'
+    coveralls: 'grunt-karma-coveralls',
+    jsdoc: 'grunt-jsdoc'
   })
 
   // Configurable paths for the application
@@ -65,6 +66,18 @@ module.exports = function(grunt) {
           '.tmp/styles/**/*.css',
           '<%= yeoman.app %>/images/**/*.{png,jpg,jpeg,gif,webp,svg}'
         ]
+      }
+    },
+
+    jsdoc: {
+      dist: {
+        src: ['app/scripts/**/*.js'],
+        options: {
+          destination: appConfig.dist + '/doc',
+          readme: 'README.md',
+          template: 'node_modules/ink-docstrap/template',
+          configure: 'jsdoc.conf.json'
+        }
       }
     },
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ $ npm install && grunt serve
 To run a production server use `npm start` and to run the unit tests use `grunt test`
 Before contributing please read the [guidelines](https://github.com/10alab/Siurana/blob/develop/CONTRIBUTION.md)
 
+To generate the documentation run `grunt jsdoc` and browse `dist/doc/index.html`
+
 Technologies
 -----
 

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -1,8 +1,24 @@
 'use strict'
 
-angular.module('climbingMemo', ['ngRoute','ui.bootstrap','hc.marked',
-'jlareau.pnotify', 'ngStorage', 'uiGmapgoogle-maps', 'datatables', 'ngTouch',
-'datatables.bootstrap', 'angular-timeline', 'angular-scroll-animate'])
+/**
+* @module climbingMemo
+* @name climbingMemo.app:climbingMemo
+* @description
+* Angular module climbingMemo
+*/
+angular.module('climbingMemo', [
+  'ngRoute',
+  'ui.bootstrap',
+  'hc.marked',
+  'jlareau.pnotify',
+  'ngStorage',
+  'uiGmapgoogle-maps',
+  'datatables',
+  'ngTouch',
+  'datatables.bootstrap',
+  'angular-timeline',
+  'angular-scroll-animate'
+])
 
 angular.module('climbingMemo')
 .config(function($routeProvider) {

--- a/app/scripts/controllers/chartsCtrl.js
+++ b/app/scripts/controllers/chartsCtrl.js
@@ -1,5 +1,12 @@
 'use strict'
 
+/**
+* @module climbingMemo
+* @name climbingMemo.controller:chartsCtrl
+* @description
+* # chartsCtrl
+* Controller of the climbingMemo
+*/
 angular.module('climbingMemo')
 .controller('chartsCtrl', function($scope, $rootScope, utilsRouteSvc) {
 
@@ -15,7 +22,12 @@ angular.module('climbingMemo')
     })
   })
 
-  // Init Controller
+  /**
+  * Initialize controller
+  *
+  * @method initController
+  * @param {Object} data
+  */
   $scope.initController = function(data) {
     $scope.routes = _.toArray(data)
   }

--- a/app/scripts/controllers/mapCtrl.js
+++ b/app/scripts/controllers/mapCtrl.js
@@ -1,5 +1,12 @@
 'use strict'
 
+/**
+* @module climbingMemo
+* @name climbingMemo.controller:mapCtrl
+* @description
+* # mapCtrl
+* Controller of the climbingMemo
+*/
 angular.module('climbingMemo')
 .controller('mapCtrl', function($localStorage, $log, $scope,
 $rootScope, mapChartSvc, utilsRouteSvc) {

--- a/app/scripts/controllers/modaladdroute.js
+++ b/app/scripts/controllers/modaladdroute.js
@@ -1,7 +1,7 @@
 'use strict'
 
 /**
-* @ngdoc function
+* @module climbingMemo
 * @name climbingMemo.controller:ModaladdrouteCtrl
 * @description
 * # ModaladdrouteCtrl

--- a/app/scripts/controllers/modalslider.js
+++ b/app/scripts/controllers/modalslider.js
@@ -1,7 +1,7 @@
 'use strict'
 
 /**
-* @ngdoc function
+* @module climbingMemo
 * @name climbingMemo.controller:ModalsliderCtrl
 * @description
 * # ModalsliderCtrl

--- a/app/scripts/controllers/navbarCtrl.js
+++ b/app/scripts/controllers/navbarCtrl.js
@@ -1,5 +1,12 @@
 'use strict'
 
+/**
+* @module climbingMemo
+* @name climbingMemo.controller:navbarCtrl
+* @description
+* # navbarCtrl
+* Controller of the climbingMemo
+*/
 angular.module('climbingMemo')
 .controller('navbarCtrl', function($scope, $location, $rootScope,
 utilsRouteSvc, $localStorage, notificationService) {

--- a/app/scripts/controllers/overviewCtrl.js
+++ b/app/scripts/controllers/overviewCtrl.js
@@ -1,5 +1,12 @@
 'use strict'
 
+/**
+* @module climbingMemo
+* @name climbingMemo.controller:overviewCtrl
+* @description
+* # overviewCtrl
+* Controller of the climbingMemo
+*/
 angular.module('climbingMemo')
 .controller('overviewCtrl', function($scope, $localStorage, $log,
 $rootScope, utilsChartSvc, utilsRouteSvc) {
@@ -16,7 +23,11 @@ $rootScope, utilsChartSvc, utilsRouteSvc) {
     })
   })
 
-  // Init Controller
+  /**
+  * Initialize Controller
+  * @method initController
+  * @param {Object} data
+  */
   $scope.initController = function(data) {
     var arrayRoutes = _.toArray(data)
     var arraySectors = utilsChartSvc.arrayGroupBy(arrayRoutes,"sector")

--- a/app/scripts/controllers/tableCtrl.js
+++ b/app/scripts/controllers/tableCtrl.js
@@ -1,5 +1,12 @@
 'use strict'
 
+/**
+* @module climbingMemo
+* @name climbingMemo.controller:tableCtrl
+* @description
+* # tableCtrl
+* Controller of the climbingMemo
+*/
 angular.module('climbingMemo')
 .controller('tableCtrl', function($scope, $rootScope, $modal, utilsChartSvc,
 utilsRouteSvc, DTOptionsBuilder) {

--- a/app/scripts/controllers/timeline.js
+++ b/app/scripts/controllers/timeline.js
@@ -1,7 +1,7 @@
 'use strict'
 
 /**
-* @ngdoc function
+* @module climbingMemo
 * @name climbingMemo.controller:TimelineCtrl
 * @description
 * # TimelineCtrl

--- a/app/scripts/directives/charts/horizontalBarChart.js
+++ b/app/scripts/directives/charts/horizontalBarChart.js
@@ -1,5 +1,12 @@
 'user strict'
 
+/**
+* @module climbingMemo
+* @name climbingMemo.directive:horizontalBarChart
+* @description
+* # horizontalBarChart
+* Directive of the climbingMemo
+*/
 angular.module('climbingMemo')
 .directive('horizontalBarChart', function(horizontalBarChartSvc, utilsChartSvc,
 $modal, $window) {

--- a/app/scripts/directives/charts/overviewChart.js
+++ b/app/scripts/directives/charts/overviewChart.js
@@ -1,5 +1,12 @@
 'user strict'
 
+/**
+* @module climbingMemo
+* @name climbingMemo.directive:overviewChart
+* @description
+* # overviewChart
+* Directive of the climbingMemo
+*/
 angular.module('climbingMemo')
 .directive('overviewChart', function(overviewChartSvc, $modal, utilsChartSvc) {
   // Private 5 digit chart ID

--- a/app/scripts/directives/charts/scatterPlotChart.js
+++ b/app/scripts/directives/charts/scatterPlotChart.js
@@ -1,5 +1,12 @@
 'user strict'
 
+/**
+* @module climbingMemo
+* @name climbingMemo.directive:scatterPlotChart
+* @description
+* # scatterPlotChart
+* Directive of the climbingMemo
+*/
 angular.module('climbingMemo')
 .directive('scatterPlotChart', function(scatterPlotChartSvc, utilsChartSvc,
 $modal, $window) {

--- a/app/scripts/directives/charts/treemapchart.js
+++ b/app/scripts/directives/charts/treemapchart.js
@@ -1,7 +1,7 @@
 'use strict'
 
 /**
-* @ngdoc directive
+* @module climbingMemo
 * @name climbingMemo.directive:treemapChart
 * @description
 * # treemapChart

--- a/app/scripts/directives/charts/verticalBarChart.js
+++ b/app/scripts/directives/charts/verticalBarChart.js
@@ -1,5 +1,12 @@
 'user strict'
 
+/**
+* @module climbingMemo
+* @name climbingMemo.directive:verticalBarChart
+* @description
+* # verticalBarChart
+* Directive of the climbingMemo
+*/
 angular.module('climbingMemo')
 .directive('verticalBarChart', function(verticalBarChartSvc, utilsChartSvc,
 $modal, $window) {

--- a/app/scripts/directives/headerDescription.js
+++ b/app/scripts/directives/headerDescription.js
@@ -1,5 +1,12 @@
 'use strict'
 
+/**
+* @module climbingMemo
+* @name climbingMemo.directive:headerDescription
+* @description
+* # headerDescription
+* Directive of the climbingMemo
+*/
 angular.module('climbingMemo')
 .directive('headerDescription', function() {
   return {

--- a/app/scripts/directives/headerOverview.js
+++ b/app/scripts/directives/headerOverview.js
@@ -1,5 +1,14 @@
 'user strict'
 
+/**
+* @module climbingMemo
+* @name climbingMemo.directive:headerOverview
+* @description
+* # headerOverview
+* Directive of the climbingMemo
+* @example
+* <header-overview></header-overview>
+*/
 angular.module('climbingMemo')
 .directive('headerOverview', function() {
   return {

--- a/app/scripts/directives/mainNavbar.js
+++ b/app/scripts/directives/mainNavbar.js
@@ -1,5 +1,12 @@
 'user strict'
 
+/**
+* @module climbingMemo
+* @name climbingMemo.directive:mainNavbar
+* @description
+* # mainNavbar
+* Directive of the climbingMemo
+*/
 angular.module('climbingMemo')
 .directive('mainNavbar', function() {
   return {

--- a/app/scripts/directives/sectorsmetrics.js
+++ b/app/scripts/directives/sectorsmetrics.js
@@ -1,7 +1,7 @@
 'use strict'
 
 /**
-* @ngdoc directive
+* @module climbingMemo
 * @name climbingMemo.directive:sectorsMetrics
 * @description
 * # sectorsMetrics

--- a/app/scripts/directives/slidercharts.js
+++ b/app/scripts/directives/slidercharts.js
@@ -1,8 +1,8 @@
 'use strict'
 
 /**
-* @ngdoc type
-* @name climbingMemo.type:sliderCharts
+* @module climbingMemo
+* @name climbingMemo.directive:sliderCharts
 * @description
 * # sliderCharts
 */

--- a/app/scripts/filters/routenoteformatting.js
+++ b/app/scripts/filters/routenoteformatting.js
@@ -1,15 +1,24 @@
 'use strict'
 
 /**
-* @ngdoc filter
+* @module climbingMemo
 * @name climbingMemo.filter:routeNoteFormatting
-* @function
 * @description
 * # routeNoteFormatting
 * Filter in the climbingMemo.
 */
 angular.module('climbingMemo')
 .filter('routeNoteFormatting', function() {
+  /**
+  * Add placeholder description
+  * @method routeNoteFormatting
+  * @param {String} input
+  * @returns {String}
+  * @example
+  * var routeName = ''
+  * var output = routeNoteFormatting(routeName)
+  * // output contains: ```\nReminder\n``` [...]
+  */
   return function(input) {
     return input ? input : '```\nReminder:\n```\n\n**Description**\n\n> \n\n----\n'
   }

--- a/app/scripts/services/charts/horizontalBarChartSvc.js
+++ b/app/scripts/services/charts/horizontalBarChartSvc.js
@@ -1,5 +1,12 @@
 'use strict'
 
+/**
+* @module climbingMemo
+* @name climbingMemo.service:horizontalBarChartSvc
+* @description
+* # horizontalBarChartSvc
+* Service of the climbingMemo
+*/
 angular.module('climbingMemo')
 .service('horizontalBarChartSvc', function horizontalBarChartSvc(utilsChartSvc) {
   /**

--- a/app/scripts/services/charts/overviewChartSvc.js
+++ b/app/scripts/services/charts/overviewChartSvc.js
@@ -1,5 +1,12 @@
 'use strict'
 
+/**
+* @module climbingMemo
+* @name climbingMemo.service:overviewChartSvc
+* @description
+* # overviewChartSvc
+* Service of the climbingMemo
+*/
 angular.module('climbingMemo')
 .service('overviewChartSvc', function overviewChartSvc(utilsChartSvc) {
   /**

--- a/app/scripts/services/charts/scatterPlotChartSvc.js
+++ b/app/scripts/services/charts/scatterPlotChartSvc.js
@@ -1,5 +1,12 @@
 'use strict'
 
+/**
+* @module climbingMemo
+* @name climbingMemo.service:scatterPlotChartSvc
+* @description
+* # scatterPlotChartSvc
+* Service of the climbingMemo
+*/
 angular.module('climbingMemo')
 .service('scatterPlotChartSvc', function scatterPlotChartSvc(utilsChartSvc) {
 

--- a/app/scripts/services/charts/treemapchartsvc.js
+++ b/app/scripts/services/charts/treemapchartsvc.js
@@ -1,8 +1,8 @@
 'use strict'
 
 /**
-* @ngdoc service
-* @name climbingMemo.treemapChartSvc
+* @module climbingMemo
+* @name climbingMemo.service:treemapChartSvc
 * @description
 * # treemapChartSvc
 * Service in the climbingMemo.

--- a/app/scripts/services/charts/utilsChartSvc.js
+++ b/app/scripts/services/charts/utilsChartSvc.js
@@ -1,5 +1,12 @@
 'use strict'
 
+/**
+* @module climbingMemo
+* @name climbingMemo.service:utilsChartSvc
+* @description
+* # utilsChartSvc
+* Service in the climbingMemo.
+*/
 angular.module('climbingMemo')
 .service('utilsChartSvc', function utilsChartSvc() {
   /**

--- a/app/scripts/services/charts/verticalBarChartSvc.js
+++ b/app/scripts/services/charts/verticalBarChartSvc.js
@@ -1,5 +1,12 @@
 'use strict'
 
+/**
+* @module climbingMemo
+* @name climbingMemo.service:verticalBarChartSvc
+* @description
+* # verticalBarChartSvc
+* Service of the climbingMemo
+*/
 angular.module('climbingMemo')
 .service('verticalBarChartSvc', function verticalBarChartSvc(utilsChartSvc) {
   /**

--- a/app/scripts/services/mapchartsvc.js
+++ b/app/scripts/services/mapchartsvc.js
@@ -1,10 +1,10 @@
 'use strict'
 
 /**
-* @ngdoc service
-* @name climbingMemo.mapChartSvc.js
+* @module climbingMemo
+* @name climbingMemo.service:mapChartSvc
 * @description
-* # mapChartSvc.js
+* # mapChartSvc
 * Service in the climbingMemo.
 */
 angular.module('climbingMemo')

--- a/app/scripts/services/routesSvc.js
+++ b/app/scripts/services/routesSvc.js
@@ -1,5 +1,12 @@
 'use strict'
 
+/**
+* @module climbingMemo
+* @name climbingMemo.factory:routesSvc
+* @description
+* # routesSvc
+* Factory of the climbingMemo
+*/
 angular.module('climbingMemo')
 .factory('routesSvc', function routeSvc($http, DATABASE_URL, $rootScope,
 $localStorage) {

--- a/app/scripts/services/timeline.js
+++ b/app/scripts/services/timeline.js
@@ -1,8 +1,8 @@
 'use strict'
 
 /**
-* @ngdoc service
-* @name climbingMemo.timeline
+* @module climbingMemo
+* @name climbingMemo.service:timelineSvc
 * @description
 * # timeline
 * Service in the climbingMemo.
@@ -12,7 +12,6 @@ angular.module('climbingMemo')
 
   /**
   * Pre-process data to be rendered on a timeline
-  *
   * @params {Array} Flat routes objects
   * @return {Object} Tree of properties
   */

--- a/app/scripts/services/utilsroutesvc.js
+++ b/app/scripts/services/utilsroutesvc.js
@@ -1,8 +1,8 @@
 'use strict'
 
 /**
-* @ngdoc service
-* @name climbingMemo.utilsRouteSvc
+* @module climbingMemo
+* @name climbingMemo.service:utilsRouteSvc
 * @description
 * # utilsRouteSvc
 * Service in the climbingMemo.

--- a/jsdoc.conf.json
+++ b/jsdoc.conf.json
@@ -1,0 +1,28 @@
+{
+  "tags": {
+    "allowUnknownTags": true
+  },
+  "plugins": ["plugins/markdown"],
+  "templates": {
+    "logoFile": "",
+    "cleverLinks": false,
+    "monospaceLinks": false,
+    "dateFormat": "ddd MMM Do YYYY",
+    "outputSourceFiles": true,
+    "outputSourcePath": true,
+    "systemName": "Climbing Memo",
+    "footer": "",
+    "copyright": "10alab Copyright © 2014-2015",
+    "navType": "vertical",
+    "theme": "cosmo",
+    "linenums": true,
+    "collapseSymbols": false,
+    "inverseNav": true,
+    "protocol": "html://",
+    "methodHeadingReturns": false
+  },
+  "markdown": {
+    "parser": "gfm",
+    "hardwrap": true
+  }
+}

--- a/package.json
+++ b/package.json
@@ -52,5 +52,9 @@
     "start": "node server.js",
     "test": "grunt test",
     "postinstall": "bower install && ./node_modules/.bin/grunt build"
+  },
+  "devDependencies": {
+    "grunt-jsdoc": "^1.1.0",
+    "ink-docstrap": "^1.0.2"
   }
 }


### PR DESCRIPTION
**Problem**
There is no generated documentation available for the components of the
angular application.

**Solution**

* :memo: Add jsdoc documentation generator
* :green_heart: Add task on build `grunt jsdoc`
* :art: Customize template output with docstrap

**Result**
User can read documentation at `dist/jsdoc/index.html`