### PR TITLE
Add controllerAs for top level routes

### DIFF
--- a/app/scripts/app.routes.js
+++ b/app/scripts/app.routes.js
@@ -21,19 +21,23 @@ angular.module('climbingMemo')
   })
   .when('/table', {
     controller: 'tableCtrl',
-    templateUrl: 'views/table.html'
+    templateUrl: 'views/table.html',
+    controllerAs: 'tableVm'
   })
   .when('/timeline', {
     controller: 'TimelineCtrl',
-    templateUrl: 'views/timeline.html'
+    templateUrl: 'views/timeline.html',
+    controllerAs: 'timelineVm'
   })
   .when('/map', {
     controller: 'mapCtrl',
-    templateUrl: 'views/map.html'
+    templateUrl: 'views/map.html',
+    controllerAs: 'mapVm'
   })
   .when('/charts', {
     controller: 'chartsCtrl',
-    templateUrl: 'views/charts.html'
+    templateUrl: 'views/charts.html',
+    controllerAs: 'chartsVm'
   })
   .otherwise({
     redirectTo: '/timeline'

--- a/app/scripts/controllers/chartsCtrl.js
+++ b/app/scripts/controllers/chartsCtrl.js
@@ -12,21 +12,23 @@
   .controller('chartsCtrl', chartsController)
 
   chartsController.$inject = [
-    '$scope',
     '$rootScope',
     'utilsRouteSvc'
   ]
 
-  function chartsController($scope, $rootScope, utilsRouteSvc) {
+  function chartsController($rootScope, utilsRouteSvc) {
+    /* jshint validthis:true */
+
+    var vm = this
     // Get Data
     utilsRouteSvc.getRoutes().then(function(data) {
-      $scope.initController(data)
+      vm.initController(data)
     })
 
     // Watch Update event
     $rootScope.$on('routesUpdated', function() {
       utilsRouteSvc.getRoutes().then(function(data) {
-        $scope.initController(data)
+        vm.initController(data)
       })
     })
 
@@ -36,8 +38,8 @@
     * @method initController
     * @param {Object} data
     */
-    $scope.initController = function(data) {
-      $scope.routes = _.toArray(data)
+    vm.initController = function(data) {
+      vm.routes = _.toArray(data)
     }
   }
 })()

--- a/app/scripts/controllers/mapCtrl.js
+++ b/app/scripts/controllers/mapCtrl.js
@@ -14,23 +14,25 @@
   mapController.$inject = [
     '$localStorage',
     '$log',
-    '$scope',
     '$rootScope',
     'mapChartSvc',
     'utilsRouteSvc'
   ]
 
-  function mapController($localStorage, $log, $scope, $rootScope, mapChartSvc,
+  function mapController($localStorage, $log, $rootScope, mapChartSvc,
   utilsRouteSvc) {
+    /* jshint validthis:true */
+    var vm = this
+
     // Get Data
     utilsRouteSvc.getRoutes().then(function(data) {
-      $scope.initController(data)
+      vm.initController(data)
     })
 
     // Watch Update event
     $rootScope.$on('routesUpdated', function() {
       utilsRouteSvc.getRoutes().then(function(data) {
-        $scope.initController(data)
+        vm.initController(data)
       })
     })
 
@@ -40,21 +42,21 @@
     * @method initController
     * @param {Object} routes
     */
-    $scope.initController = function(routes) {
-      $scope.offline = !$rootScope.online
+    vm.initController = function(routes) {
+      vm.offline = !$rootScope.online
 
       var arrayRoutes = _.toArray(routes)
       var arrayLocations = mapChartSvc.processData(arrayRoutes)
 
       _.map(arrayLocations, function(site) {
         site.options = {
-          icon: 'images/' + $scope.getMarkerIcon(site.metrics[0].type)
+          icon: 'images/' + vm.getMarkerIcon(site.metrics[0].type)
         }
         return site
       })
 
-      $scope.locations = arrayLocations
-      $scope.map = { center: { latitude: 37.7833, longitude: -122.4167 }, zoom: 8 }
+      vm.locations = arrayLocations
+      vm.map = { center: { latitude: 37.7833, longitude: -122.4167 }, zoom: 8 }
     }
 
     /**
@@ -64,7 +66,7 @@
     * @param {String} type
     * @return {String}
     */
-    $scope.getMarkerIcon = function(type) {
+    vm.getMarkerIcon = function(type) {
       var markerIcon = ''
 
       switch (type) {

--- a/app/scripts/controllers/tableCtrl.js
+++ b/app/scripts/controllers/tableCtrl.js
@@ -12,7 +12,6 @@
   .controller('tableCtrl', tableController)
 
   tableController.$inject = [
-    '$scope',
     '$rootScope',
     '$modal',
     'utilsChartSvc',
@@ -20,15 +19,18 @@
     'DTOptionsBuilder'
   ]
 
-  function tableController($scope, $rootScope, $modal, utilsChartSvc, utilsRouteSvc,
+  function tableController($rootScope, $modal, utilsChartSvc, utilsRouteSvc,
   DTOptionsBuilder) {
+    /* jshint validthis:true */
+    var vm = this
+
     // Get Data
     utilsRouteSvc.getRoutes().then(function(data) {
-      $scope.initController(data)
+      vm.initController(data)
     })
 
-    $scope.dtInstance = {}
-    $scope.dtOptions = DTOptionsBuilder
+    vm.dtInstance = {}
+    vm.dtOptions = DTOptionsBuilder
       .newOptions()
       .withBootstrap()
       .withOption('sDom', "<'no-row'" +
@@ -54,7 +56,7 @@
     // Watch Update event
     $rootScope.$on('routesUpdated', function() {
       utilsRouteSvc.getRoutes().then(function(data) {
-        $scope.initController(data)
+        vm.initController(data)
       })
     })
 
@@ -63,8 +65,8 @@
     *
     * @method nextPage
     */
-    $scope.nextPage = function() {
-      var dtApi = $($scope.dtInstance.dataTable[0]).dataTable().api() // jshint ignore:line
+    vm.nextPage = function() {
+      var dtApi = $(vm.dtInstance.dataTable[0]).dataTable().api() // jshint ignore:line
       dtApi.page('next').draw('page')
     }
 
@@ -73,8 +75,8 @@
     *
     * @method previousPage
     */
-    $scope.previousPage = function() {
-      var dtApi = $($scope.dtInstance.dataTable[0]).dataTable().api() // jshint ignore:line
+    vm.previousPage = function() {
+      var dtApi = $(vm.dtInstance.dataTable[0]).dataTable().api() // jshint ignore:line
       dtApi.page('previous').draw('page')
     }
 
@@ -85,20 +87,20 @@
     * @method initController
     * @param {Object} Routes
     */
-    $scope.initController = function(data) {
+    vm.initController = function(data) {
       var count = 0
       _.map(data, function(route, key) {
         route.$date    = route.date
         route.$id      = key
         count++
       })
-      $scope.routes = _.toArray(data)
+      vm.routes = _.toArray(data)
 
-      var arrayLocations = utilsChartSvc.arrayGroupBy($scope.routes,"location")
-      var arraySectors   = utilsChartSvc.arrayGroupBy($scope.routes,"sector")
+      var arrayLocations = utilsChartSvc.arrayGroupBy(vm.routes,"location")
+      var arraySectors   = utilsChartSvc.arrayGroupBy(vm.routes,"sector")
 
-      $scope.locations = arrayLocations
-      $scope.sectors   = arraySectors
+      vm.locations = arrayLocations
+      vm.sectors   = arraySectors
     }
 
     /**
@@ -109,7 +111,7 @@
      *
      * @return {String} Css color
      */
-    $scope.getTypeColor = function(route) {
+    vm.getTypeColor = function(route) {
       return utilsRouteSvc.getTypeColor(route)
     }
 
@@ -118,7 +120,7 @@
     *
     * @method addRoute
     */
-    $scope.addRoute = function() {
+    vm.addRoute = function() {
       $modal.open({
         templateUrl: 'views/_modalAddRoute.html',
         controller: 'ModaladdrouteCtrl',
@@ -131,7 +133,7 @@
     *
     * @method openRouteModal
     */
-    $scope.openRouteModal = function(route) {
+    vm.openRouteModal = function(route) {
       $modal.open({
         templateUrl: 'views/sliderModal.html',
         controller: 'ModalsliderCtrl',
@@ -143,6 +145,5 @@
         }
       })
     }
-
   }
 })()

--- a/app/scripts/controllers/timeline.js
+++ b/app/scripts/controllers/timeline.js
@@ -12,7 +12,6 @@
   .controller('TimelineCtrl', timelineController)
 
   timelineController.$inject = [
-    '$scope',
     '$localStorage',
     '$log',
     '$rootScope',
@@ -21,17 +20,20 @@
     'utilsRouteSvc'
   ]
 
-  function timelineController($scope, $localStorage, $log, $rootScope,
+  function timelineController($localStorage, $log, $rootScope,
   $modal,timelineSvc, utilsRouteSvc) {
+    /* jshint validthis:true */
+    var vm = this
+
     // Get Data
     utilsRouteSvc.getRoutes().then(function(data) {
-      $scope.initController(data)
+      vm.initController(data)
     })
 
     // Watch Update event
     $rootScope.$on('routesUpdated', function() {
       utilsRouteSvc.getRoutes().then(function(data) {
-        $scope.initController(data)
+        vm.initController(data)
       })
     })
 
@@ -44,7 +46,7 @@
     *
     * @return {String} Css color
     */
-    $scope.getTypeColor = function(event) {
+    vm.getTypeColor = function(event) {
       return utilsRouteSvc.getTypeColor({type: event.mainType})
     }
 
@@ -55,7 +57,7 @@
     * @param {Boolean} event
     * @return {String}
     */
-    $scope.getBadgeTooltip = function(event) {
+    vm.getBadgeTooltip = function(event) {
       return (event.isIndoor ? 'Indoor' : 'Outdoor') + ' ' + event.mainType
     }
 
@@ -66,7 +68,7 @@
     * @param {Boolean} event
     * @return {String}
     */
-    $scope.getBadgeIcon = function(event) {
+    vm.getBadgeIcon = function(event) {
       return 'fa ' + (event.isIndoor ? 'fa-home' : 'fa-sun-o')
     }
 
@@ -77,7 +79,7 @@
     * @param {Object} route - First route to display
     * @param {Array} routes - All routes in slider
     */
-    $scope.openRouteModal = function(route, routes) {
+    vm.openRouteModal = function(route, routes) {
       $modal.open({
         templateUrl: 'views/sliderModal.html',
         controller: 'ModalsliderCtrl',
@@ -99,7 +101,7 @@
     *
     * @method addRoute
     */
-    $scope.addRoute = function() {
+    vm.addRoute = function() {
       $modal.open({
         templateUrl: 'views/_modalAddRoute.html',
         controller: 'ModaladdrouteCtrl',
@@ -108,11 +110,11 @@
     }
 
     // Init Controller
-    $scope.initController = function(data) {
+    vm.initController = function(data) {
       var arrayRoutes = _.toArray(data)
       var events = timelineSvc.processData(arrayRoutes)
 
-      $scope.events = events
+      vm.events = events
     }
   }
 })()

--- a/app/views/_gridCharts.html
+++ b/app/views/_gridCharts.html
@@ -7,7 +7,7 @@
         <h3 class="panel-title"><span class="fa fa-star-o"></span> Sector quality</h3>
       </div>
       <div class="panel-body">
-        <scatter-plot-chart routes="routes"></scatter-plot-chart>
+        <scatter-plot-chart routes="chartsVm.routes"></scatter-plot-chart>
       </div>
     </div>
 
@@ -21,7 +21,7 @@
         <h3 class="panel-title"><span class="fa fa-bar-chart"></span> Climb quantity</h3>
       </div>
       <div class="panel-body">
-        <vertical-bar-chart routes="routes"></vertical-bar-chart>
+        <vertical-bar-chart routes="chartsVm.routes"></vertical-bar-chart>
       </div>
     </div>
 
@@ -38,7 +38,7 @@
         <h3 class="panel-title"><span class="fa fa-bar-chart"></span> Favorite climb type difficulty</h3>
       </div>
       <div class="panel-body">
-        <horizontal-bar-chart routes="routes"></horizontal-bar-chart>
+        <horizontal-bar-chart routes="chartsVm.routes"></horizontal-bar-chart>
       </div>
     </div>
 
@@ -52,7 +52,7 @@
         <h3 class="panel-title"><span class="fa fa-th-large"></span> Climb diversity</h3>
       </div>
       <div class="panel-body">
-        <treemap-chart routes="routes"></treemap-chart>
+        <treemap-chart routes="chartsVm.routes"></treemap-chart>
       </div>
     </div>
 

--- a/app/views/charts.html
+++ b/app/views/charts.html
@@ -1,7 +1,7 @@
 <div class="charts">
 
   <div class="visible-xs">
-    <slider-charts routes="routes"></slider-charts>
+    <slider-charts routes="chartsVm.routes"></slider-charts>
   </div>
 
   <div class="hidden-xs">

--- a/app/views/map.html
+++ b/app/views/map.html
@@ -4,9 +4,9 @@
       <h3 class="panel-title"><span class="fa fa-globe"></span> Routes Locations</h3>
     </div>
     <div class="panel-body">
-      <div class="alert alert-info" role="alert" ng-if="offline">Offline Mode</div>
-      <ui-gmap-google-map center='map.center' zoom='map.zoom'>
-      <ui-gmap-marker ng-repeat="location in locations" idKey='location.name'
+      <div class="alert alert-info" role="alert" ng-if="mapVm.offline">Offline Mode</div>
+      <ui-gmap-google-map center='mapVm.map.center' zoom='mapVm.map.zoom'>
+      <ui-gmap-marker ng-repeat="location in mapVm.locations" idKey='location.name'
       coords='location.coords' options="location.options" >
 
       <ui-gmap-window templateUrl="'views/_windowLocationMap.html'" templateParameter="location"> </ui-gmap-window>

--- a/app/views/table.html
+++ b/app/views/table.html
@@ -7,11 +7,11 @@
 	<div class="panel-body">
 
     <p class="hidden-xs">
-      <button tooltip="Add route" class="btn btn-fab btn-raised btn-success" ng-click="addRoute()"><i class="fa fa-plus"></i></button>
+      <button tooltip="Add route" class="btn btn-fab btn-raised btn-success" ng-click="tableVm.addRoute()"><i class="fa fa-plus"></i></button>
     </p>
 
-    <div ng-swipe-left="nextPage()" ng-swipe-right="previousPage()">
-      <table data-datatable="ng" data-dt-options="dtOptions" dt-instance="dtInstance" class="table table-condensed table-hover">
+    <div ng-swipe-left="tableVm.nextPage()" ng-swipe-right="tableVm.previousPage()">
+      <table data-datatable="ng" data-dt-options="tableVm.dtOptions" dt-instance="tableVm.dtInstance" class="table table-condensed table-hover">
         <thead>
           <tr>
             <th class="">Name</th>
@@ -26,7 +26,7 @@
           </tr>
         </thead>
         <tbody>
-          <tr ng-repeat="route in routes" ng-click="openRouteModal(route)" style="cursor:pointer">
+          <tr ng-repeat="route in tableVm.routes" ng-click="tableVm.openRouteModal(route)" style="cursor:pointer">
             <td>
               <i ng-class="{'fa fa-eye': route.watch}"></i>
               <a title="Route Details">

--- a/app/views/timeline.html
+++ b/app/views/timeline.html
@@ -7,16 +7,16 @@
     <p class="text-center climb-add">
       <button tooltip="Add new route"
               class="btn btn-fab btn-raised btn-success"
-              ng-click="addRoute()">
+              ng-click="timelineVm.addRoute()">
         <i class="fa fa-plus"></i>
       </button>
     </p>
 
     <timeline>
-      <timeline-event ng-repeat="event in events">
-      <timeline-badge style="background-color:{{getTypeColor(event)}}"
-      tooltip="{{getBadgeTooltip(event)}}">
-          <i class="fa {{getBadgeIcon(event)}}"></i>
+      <timeline-event ng-repeat="event in timelineVm.events">
+      <timeline-badge style="background-color:{{ timelineVm.getTypeColor(event) }}"
+      tooltip="{{ timelineVm.getBadgeTooltip(event) }}">
+          <i class="fa {{ timelineVm.getBadgeIcon(event) }}"></i>
         </timeline-badge>
 
         <timeline-panel>

--- a/test/spec/controllers/chartsCtrl.js
+++ b/test/spec/controllers/chartsCtrl.js
@@ -20,7 +20,7 @@ describe('Controller: chartsCtrl', function() {
     deferred.resolve({})
     spyOn(utilsRouteSvc, 'getRoutes').and.returnValue(deferred.promise)
 
-    chartsCtrl = $controller('chartsCtrl', {
+    chartsCtrl = $controller('chartsCtrl as chartsVm', {
       $scope:          scope,
       utilsRouteSvc:   utilsRouteSvc
     })
@@ -36,9 +36,9 @@ describe('Controller: chartsCtrl', function() {
   })
 
   it('should #initController with new empty route', function() {
-    scope.initController({test:'data'})
+    scope.chartsVm.initController({test:'data'})
 
-    expect(scope.routes).toEqual(jasmine.any(Array))
-    expect(scope.routes.length).toBe(1)
+    expect(scope.chartsVm.routes).toEqual(jasmine.any(Array))
+    expect(scope.chartsVm.routes.length).toBe(1)
   })
 })

--- a/test/spec/controllers/mapCtrl.js
+++ b/test/spec/controllers/mapCtrl.js
@@ -27,7 +27,7 @@ describe('Controller: mapCtrl', function() {
       {metrics: [{type: 'Sport Lead'}]}
     ])
 
-    mapCtrl = $controller('mapCtrl', {
+    mapCtrl = $controller('mapCtrl as mapVm', {
       $scope:         scope,
       utilsRouteSvc:  utilsRouteSvc,
       mapChartSvc:    mapChartSvc
@@ -44,9 +44,9 @@ describe('Controller: mapCtrl', function() {
   })
 
   it('should #initController with new empty route', function() {
-    scope.initController({test:'data'})
+    scope.mapVm.initController({test:'data'})
 
-    expect(_.isEqual(scope.locations, [
+    expect(_.isEqual(scope.mapVm.locations, [
       {"metrics":[{"type":"Boulder"}],"options":{"icon":"images/climbing_blue.png"}},
       {"metrics":[{"type":"Sport Lead"}],"options":{"icon":"images/climbing_gray.png"}}
     ])).toBe(true)
@@ -55,11 +55,11 @@ describe('Controller: mapCtrl', function() {
   it('should #getMarkerIcon', function() {
     var types = ['Sport lead', 'Boulder', 'Traditional', 'Multi-pitch', 'Top rope']
 
-    expect(scope.getMarkerIcon(types[0])).toMatch(/yellow/)
-    expect(scope.getMarkerIcon(types[1])).toMatch(/blue/)
-    expect(scope.getMarkerIcon(types[2])).toMatch(/green/)
-    expect(scope.getMarkerIcon(types[3])).toMatch(/orange/)
-    expect(scope.getMarkerIcon(types[4])).toMatch(/gray/)
-    expect(scope.getMarkerIcon('undefined')).toMatch(/gray/)
+    expect(scope.mapVm.getMarkerIcon(types[0])).toMatch(/yellow/)
+    expect(scope.mapVm.getMarkerIcon(types[1])).toMatch(/blue/)
+    expect(scope.mapVm.getMarkerIcon(types[2])).toMatch(/green/)
+    expect(scope.mapVm.getMarkerIcon(types[3])).toMatch(/orange/)
+    expect(scope.mapVm.getMarkerIcon(types[4])).toMatch(/gray/)
+    expect(scope.mapVm.getMarkerIcon('undefined')).toMatch(/gray/)
   })
 })

--- a/test/spec/controllers/tableCtrl.js
+++ b/test/spec/controllers/tableCtrl.js
@@ -32,7 +32,7 @@ describe('Controller: tableCtrl', function() {
     utilsChartSvc = { arrayGroupBy: function() {} }
     spyOn(utilsChartSvc, 'arrayGroupBy').and.returnValue(['test'])
 
-    tableCtrl = $controller('tableCtrl', {
+    tableCtrl = $controller('tableCtrl as tableVm', {
       $scope:         scope,
       $modal:         modal,
       utilsRouteSvc:  utilsRouteSvc,
@@ -51,18 +51,18 @@ describe('Controller: tableCtrl', function() {
   it('should #initController', function() {
     utilsChartSvc.arrayGroupBy.calls.reset()
     var data = {key1: 'test1', key2: 'test2'}
-    scope.initController(data)
+    scope.tableVm.initController(data)
 
-    expect(scope.routes.length).toBe(2)
-    expect(scope.routes).toEqual(jasmine.any(Array))
+    expect(scope.tableVm.routes.length).toBe(2)
+    expect(scope.tableVm.routes).toEqual(jasmine.any(Array))
     expect(utilsChartSvc.arrayGroupBy).toHaveBeenCalled()
-    expect(scope.locations).toEqual(['test'])
-    expect(scope.sectors).toEqual(['test'])
+    expect(scope.tableVm.locations).toEqual(['test'])
+    expect(scope.tableVm.sectors).toEqual(['test'])
   })
 
   it('should #getTypeColor', function() {
     var route = {type: 'test'}
-    scope.getTypeColor(route)
+    scope.tableVm.getTypeColor(route)
 
     expect(utilsRouteSvc.getTypeColor).toHaveBeenCalledWith(route)
   })
@@ -70,14 +70,14 @@ describe('Controller: tableCtrl', function() {
   it('should #addRoute', function() {
     modal.open.calls.reset()
 
-    scope.addRoute()
+    scope.tableVm.addRoute()
     expect(modal.open).toHaveBeenCalled()
   })
 
   it('should #openRouteModal', function() {
     modal.open.calls.reset()
 
-    scope.openRouteModal()
+    scope.tableVm.openRouteModal()
     expect(modal.open).toHaveBeenCalled()
   })
 

--- a/test/spec/controllers/timeline.js
+++ b/test/spec/controllers/timeline.js
@@ -60,7 +60,7 @@ describe('Controller: TimelineCtrl', function() {
     }
     spyOn(timelineSvc, 'processData').and.returnValue([1,2,3])
 
-    TimelineCtrl = $controller('TimelineCtrl', {
+    TimelineCtrl = $controller('TimelineCtrl as timelineVm', {
       $scope:         scope,
       timelineSvc:    timelineSvc,
       $rootScope:     rootScope,
@@ -80,7 +80,7 @@ describe('Controller: TimelineCtrl', function() {
 
   it('should #getTypeColor', function() {
     utilsRouteSvc.getTypeColor.calls.reset()
-    scope.getTypeColor({mainType: 'test'})
+    scope.timelineVm.getTypeColor({mainType: 'test'})
 
     expect(utilsRouteSvc.getTypeColor).toHaveBeenCalled()
   })
@@ -88,7 +88,7 @@ describe('Controller: TimelineCtrl', function() {
   it('should open modal on #addRoute', function() {
     modal.open.calls.reset()
 
-    scope.addRoute()
+    scope.timelineVm.addRoute()
     expect(modal.open).toHaveBeenCalled()
   })
 
@@ -97,29 +97,29 @@ describe('Controller: TimelineCtrl', function() {
       isIndoor: true,
       mainType: 'test'
     }
-    expect(scope.getBadgeTooltip(event)).toBe('Indoor test')
+    expect(scope.timelineVm.getBadgeTooltip(event)).toBe('Indoor test')
   })
 
   it('should #getBadgeIcon', function() {
     var event = { isIndoor: true }
-    expect(scope.getBadgeIcon(event)).toBe('fa fa-home')
+    expect(scope.timelineVm.getBadgeIcon(event)).toBe('fa fa-home')
 
     event = { isIndoor: false }
-    expect(scope.getBadgeIcon(event)).toBe('fa fa-sun-o')
+    expect(scope.timelineVm.getBadgeIcon(event)).toBe('fa fa-sun-o')
   })
 
   it('should #openRouteModal', function() {
     modal.open.calls.reset()
-    scope.openRouteModal()
+    scope.timelineVm.openRouteModal()
 
     expect(modal.open).toHaveBeenCalled()
   })
 
   it('should #initController ', function() {
     timelineSvc.processData.calls.reset()
-    scope.initController({})
+    scope.timelineVm.initController({})
 
-    expect(_.size(scope.events)).toBe(3)
+    expect(_.size(scope.timelineVm.events)).toBe(3)
     expect(timelineSvc.processData).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
**Problem**
Top level controllers and views are using `$scope` where not needed.

**Solution**
Use `controllerAs` in the routesProvider and use the `this` syntax in
the controller which gets bound to `$scope`.

**Result**
The top level views have more semantic as they are bound to a unique
named controller.