### PR TITLE
Add end to end test skeleton

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ node_js:
 before_install: bundle install
 after_script:
 - cat ./coverage/report-lcov/lcov.info | ./node_modules/coveralls/bin/coveralls.js
+addons:
+  sauce_connect: true
 deploy:
   provider: heroku
   app: climbing-memo

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -518,8 +518,9 @@ module.exports = function(grunt) {
         configFile: 'test/e2e/protractor.conf.js',
         keepAlive: true,
         noColor: false,
-        webdriverManagerUpdate: true,
         args: {
+          sauceUser: process.env.SAUCE_USERNAME,
+          sauceKey: process.env.SAUCE_ACCESS_KEY
         }
       },
       run: {}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -18,7 +18,8 @@ module.exports = function(grunt) {
     ngtemplates: 'grunt-angular-templates',
     cdnify: 'grunt-google-cdn',
     coveralls: 'grunt-karma-coveralls',
-    jsdoc: 'grunt-jsdoc'
+    jsdoc: 'grunt-jsdoc',
+    protractor: 'grunt-protractor-runner'
   })
 
   // Configurable paths for the application
@@ -512,6 +513,18 @@ module.exports = function(grunt) {
       }
     },
 
+    protractor: {
+      options: {
+        configFile: 'test/e2e/protractor.conf.js',
+        keepAlive: true,
+        noColor: false,
+        webdriverManagerUpdate: true,
+        args: {
+        }
+      },
+      run: {}
+    },
+
     coveralls: {
       options: {
         coverageDir: 'coverage',
@@ -550,6 +563,18 @@ module.exports = function(grunt) {
       })
   })
 
+  grunt.registerTask('e2e-test', [
+    'connect:test',
+    'protractor:run'
+  ])
+
+  grunt.registerTask('unit-test', [
+    'jscs',
+    'jshint',
+    'karma',
+    'coveralls'
+  ])
+
   grunt.registerTask('test', [
     'clean:server',
     'wiredep',
@@ -559,6 +584,7 @@ module.exports = function(grunt) {
     'jscs',
     'jshint',
     'karma',
+    'protractor:run',
     'coveralls'
   ])
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 [![Coverage Status](https://coveralls.io/repos/10alab/Siurana/badge.svg?branch=develop&service=github)](https://coveralls.io/github/10alab/Siurana?branch=develop)
 [![Codacy Badge](https://api.codacy.com/project/badge/82b99cbb621d4ee6ae23826ec798d7cd)](https://www.codacy.com/app/cmizony/Siurana)
 [![Gitter Chat](http://img.shields.io/badge/gitter-cmizony / 10aLab-blue.svg)](https://gitter.im/cmizony/10aLab)
+[![Sauce Test Status](https://saucelabs.com/buildstatus/cmizony)](https://saucelabs.com/u/cmizony)
 
+[![Sauce Test Status](https://saucelabs.com/browser-matrix/cmizony.svg)](https://saucelabs.com/u/cmizony)
 
 # Climbing Memo
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "scripts": {
     "start": "node server.js",
-    "test": "grunt test",
+    "test": "node --harmony ./node_modules/.bin/grunt test",
     "postinstall": "bower install && ./node_modules/.bin/grunt build"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   },
   "devDependencies": {
     "grunt-jsdoc": "^1.1.0",
+    "grunt-protractor-runner": "^3.0.0",
     "ink-docstrap": "^1.0.2"
   }
 }

--- a/test/e2e/protractor.conf.js
+++ b/test/e2e/protractor.conf.js
@@ -1,0 +1,14 @@
+exports.config = {
+  specs: [
+    '**/*.spec.js'
+  ],
+
+  framework: 'jasmine',
+  jasmineNodeOpts: {
+    showColors: true
+  },
+
+  params: {
+    url: 'http:localhost:9001'
+  }
+}

--- a/test/e2e/protractor.conf.js
+++ b/test/e2e/protractor.conf.js
@@ -1,4 +1,24 @@
 exports.config = {
+  sauceUser: process.env.SAUCE_USERNAME,
+  sauceKey: process.env.SAUCE_ACCESS_KEY,
+
+  multiCapabilities: [{
+    'browserName': 'chrome',
+    'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
+    'build': process.env.TRAVIS_BUILD_NUMBER,
+    'name': 'Climbing-memo Chrome'
+  }, {
+    'browserName': 'firefox',
+    'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
+    'build': process.env.TRAVIS_BUILD_NUMBER,
+    'name': 'Climbing-memo Firefox'
+  }, {
+    'browserName': 'internet explorer',
+    'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
+    'build': process.env.TRAVIS_BUILD_NUMBER,
+    'name': 'Climbing-memo IE'
+  }],
+
   specs: [
     '**/*.spec.js'
   ],

--- a/test/e2e/timeline.spec.js
+++ b/test/e2e/timeline.spec.js
@@ -1,0 +1,9 @@
+describe('timeline page', function() {
+  it('should contain main widget', function() {
+    browser.get(browser.params.url)
+
+    var widget = element(by.css('.climb-timeline'))
+
+    expect(widget.isPresent()).toBe(true)
+  })
+})


### PR DESCRIPTION
**Problem**
It is not possible to catch UI bugs on pull requests before the code get
released.

**Solution**
Add protractor framework for end to end tests that can be run by default
on the task `grunt test`.