### PR TITLE
Add cache node_module for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ after_script:
 - cat ./coverage/report-lcov/lcov.info | ./node_modules/coveralls/bin/coveralls.js
 addons:
   sauce_connect: true
+cache:
+  directories:
+    - node_modules
 notifcations:
   webhooks:
     urls:


### PR DESCRIPTION
**Problem**
The Travis build is slow, installing node dependencies takes 300
secondes.

**Solution**
Add caching on build for Travis. Feature seem to be only supported for
private repositories. But as it was release in Dev 2013, maybe they
support for open source now?