### PR TITLE
Cache bower dependencies on build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ addons:
 cache:
   directories:
     - node_modules
+    - bower_components
 notifcations:
   webhooks:
     urls:


### PR DESCRIPTION
**Problem**
`npm install` take 60 seconds to run on Travis

**Solution**
Cache bower dependencies on Travis to make the build run faster