### PR TITLE
Fix deprecated UI bootstrap components

### DIFF
--- a/app/components/charts/directives/horizontalBarChart.js
+++ b/app/components/charts/directives/horizontalBarChart.js
@@ -12,13 +12,13 @@
   .directive('horizontalBarChart', horizontalBarChartDirective)
 
   horizontalBarChartDirective.$inject = [
-    '$modal',
+    '$uibModal',
     '$window',
     'horizontalBarChartSvc',
     'utilsChartSvc'
   ]
 
-  function horizontalBarChartDirective($modal, $window, horizontalBarChartSvc,
+  function horizontalBarChartDirective($uibModal, $window, horizontalBarChartSvc,
   utilsChartSvc) {
     // Private 5 digit chart ID
     var ID = _.random(10000, 99999)
@@ -51,7 +51,7 @@
         * @method openSliderModal
         */
         scope.openSliderModal = function(routesId) {
-          $modal.open({
+          $uibModal.open({
             templateUrl: 'views/sliderModal.html',
             controller: 'ModalsliderCtrl',
             size: 'md',

--- a/app/components/charts/directives/overviewChart.js
+++ b/app/components/charts/directives/overviewChart.js
@@ -12,12 +12,12 @@
   .directive('overviewChart', overviewChartDirective)
 
   overviewChartDirective.$inject = [
-    '$modal',
+    '$uibModal',
     'overviewChartSvc',
     'utilsChartSvc'
   ]
 
-  function overviewChartDirective($modal, overviewChartSvc, utilsChartSvc) {
+  function overviewChartDirective($uibModal, overviewChartSvc, utilsChartSvc) {
     // Private 5 digit chart ID
     var ID = _.random(10000, 99999)
 
@@ -44,7 +44,7 @@
         * @method openSliderModal
         */
         scope.openSliderModal = function(routesId) {
-          $modal.open({
+          $uibModal.open({
             templateUrl: 'views/sliderModal.html',
             controller: 'ModalsliderCtrl',
             size: 'md',

--- a/app/components/charts/directives/scatterPlotChart.js
+++ b/app/components/charts/directives/scatterPlotChart.js
@@ -12,13 +12,13 @@
   .directive('scatterPlotChart', scatterPlotChartDirective)
 
   scatterPlotChartDirective.$inject = [
-    '$modal',
+    '$uibModal',
     '$window',
     'scatterPlotChartSvc',
     'utilsChartSvc'
   ]
 
-  function scatterPlotChartDirective($modal, $window, scatterPlotChartSvc,
+  function scatterPlotChartDirective($uibModal, $window, scatterPlotChartSvc,
   utilsChartSvc) {
     // Private 5 digit chart ID
     var ID = _.random(10000, 99999)
@@ -51,7 +51,7 @@
         * @method openSliderModal
         */
         scope.openSliderModal = function(routesId) {
-          $modal.open({
+          $uibModal.open({
             templateUrl: 'views/sliderModal.html',
             controller: 'ModalsliderCtrl',
             size: 'md',

--- a/app/components/charts/directives/treemapchart.js
+++ b/app/components/charts/directives/treemapchart.js
@@ -12,12 +12,12 @@
 
   treemapChartDirective.$inject = [
     '$window',
-    '$modal',
+    '$uibModal',
     'treemapChartSvc',
     'utilsChartSvc'
   ]
 
-  function treemapChartDirective($window, $modal, treemapChartSvc,
+  function treemapChartDirective($window, $uibModal, treemapChartSvc,
   utilsChartSvc) {
     // Private 5 digit chart ID
     var ID = _.random(10000, 99999)
@@ -48,7 +48,7 @@
         * @method openSliderModal
         */
         scope.openSliderModal = function(routesId) {
-          $modal.open({
+          $uibModal.open({
             templateUrl: 'views/sliderModal.html',
             controller: 'ModalsliderCtrl',
             size: 'md',

--- a/app/components/charts/directives/verticalBarChart.js
+++ b/app/components/charts/directives/verticalBarChart.js
@@ -12,13 +12,13 @@
   .directive('verticalBarChart', verticalBarChartDirective)
 
   verticalBarChartDirective.$inject = [
-    '$modal',
+    '$uibModal',
     '$window',
     'verticalBarChartSvc',
     'utilsChartSvc'
   ]
 
-  function verticalBarChartDirective($modal, $window, verticalBarChartSvc,
+  function verticalBarChartDirective($uibModal, $window, verticalBarChartSvc,
   utilsChartSvc) {
     // Private 5 digit chart ID
     var ID = _.random(10000, 99999)
@@ -51,7 +51,7 @@
         * @method openSliderModal
         */
         scope.openSliderModal = function(routesId) {
-          $modal.open({
+          $uibModal.open({
             templateUrl: 'views/sliderModal.html',
             controller: 'ModalsliderCtrl',
             size: 'md',

--- a/app/scripts/controllers/modaladdroute.js
+++ b/app/scripts/controllers/modaladdroute.js
@@ -12,7 +12,7 @@
   .controller('ModaladdrouteCtrl', modalAddRouteController)
 
   modalAddRouteController.$inject = [
-    '$modalInstance',
+    '$uibModalInstance',
     '$scope',
     '$rootScope',
     '$log',
@@ -21,7 +21,7 @@
     'utilsRouteSvc'
   ]
 
-  function modalAddRouteController($modalInstance, $scope, $rootScope, $log,
+  function modalAddRouteController($uibModalInstance, $scope, $rootScope, $log,
   routeNoteFormattingFilter, utilsChartSvc, utilsRouteSvc)  {
     // Buffer for all routes
     $scope.arrayRoutes = []
@@ -44,7 +44,7 @@
     * @method cancelEdit
     */
     $scope.cancelEdit = function() {
-      $modalInstance.dismiss('cancel')
+      $uibModalInstance.dismiss('cancel')
     }
 
     /**

--- a/app/scripts/controllers/modalslider.js
+++ b/app/scripts/controllers/modalslider.js
@@ -13,7 +13,7 @@
 
   modalSliderController.$inject = [
     '$scope',
-    '$modalInstance',
+    '$uibModalInstance',
     '$localStorage',
     '$log',
     '$rootScope',
@@ -23,7 +23,7 @@
     'utilsRouteSvc'
   ]
 
-  function modalSliderController($scope, $modalInstance, $localStorage, $log,
+  function modalSliderController($scope, $uibModalInstance, $localStorage, $log,
   $rootScope, $filter, routesId, routeNoteFormattingFilter, utilsRouteSvc) {
 
     /**
@@ -32,7 +32,7 @@
     * @method closeModal
     */
     $scope.closeModal = function() {
-      $modalInstance.dismiss('cancel')
+      $uibModalInstance.dismiss('cancel')
     }
 
     // Get Data

--- a/app/scripts/controllers/tableCtrl.js
+++ b/app/scripts/controllers/tableCtrl.js
@@ -13,13 +13,13 @@
 
   tableController.$inject = [
     '$rootScope',
-    '$modal',
+    '$uibModal',
     'utilsChartSvc',
     'utilsRouteSvc',
     'DTOptionsBuilder'
   ]
 
-  function tableController($rootScope, $modal, utilsChartSvc, utilsRouteSvc,
+  function tableController($rootScope, $uibModal, utilsChartSvc, utilsRouteSvc,
   DTOptionsBuilder) {
     /* jshint validthis:true */
     var vm = this
@@ -121,7 +121,7 @@
     * @method addRoute
     */
     vm.addRoute = function() {
-      $modal.open({
+      $uibModal.open({
         templateUrl: 'views/_modalAddRoute.html',
         controller: 'ModaladdrouteCtrl',
         size: 'md'
@@ -134,7 +134,7 @@
     * @method openRouteModal
     */
     vm.openRouteModal = function(route) {
-      $modal.open({
+      $uibModal.open({
         templateUrl: 'views/sliderModal.html',
         controller: 'ModalsliderCtrl',
         size: 'md',

--- a/app/scripts/controllers/timeline.js
+++ b/app/scripts/controllers/timeline.js
@@ -15,13 +15,13 @@
     '$localStorage',
     '$log',
     '$rootScope',
-    '$modal',
+    '$uibModal',
     'timelineSvc',
     'utilsRouteSvc'
   ]
 
   function timelineController($localStorage, $log, $rootScope,
-  $modal,timelineSvc, utilsRouteSvc) {
+  $uibModal,timelineSvc, utilsRouteSvc) {
     /* jshint validthis:true */
     var vm = this
 
@@ -80,7 +80,7 @@
     * @param {Array} routes - All routes in slider
     */
     vm.openRouteModal = function(route, routes) {
-      $modal.open({
+      $uibModal.open({
         templateUrl: 'views/sliderModal.html',
         controller: 'ModalsliderCtrl',
         size: 'md',
@@ -102,7 +102,7 @@
     * @method addRoute
     */
     vm.addRoute = function() {
-      $modal.open({
+      $uibModal.open({
         templateUrl: 'views/_modalAddRoute.html',
         controller: 'ModaladdrouteCtrl',
         size: 'md'

--- a/app/scripts/directives/sectorsmetrics.js
+++ b/app/scripts/directives/sectorsmetrics.js
@@ -19,7 +19,7 @@
       scope: {
         metrics: '='
       },
-      controller: function($scope, $modal) {
+      controller: function($scope, $uibModal) {
         /**
         * Open a modal to display routes details
         *
@@ -27,7 +27,7 @@
         * @param {Array} routes - routes of Id
         */
         $scope.openRoutesModal = function(routesId) {
-          $modal.open({
+          $uibModal.open({
             templateUrl: 'views/sliderModal.html',
             controller: 'ModalsliderCtrl',
             size: 'md',

--- a/app/views/_cardAddRoute.html
+++ b/app/views/_cardAddRoute.html
@@ -1,13 +1,13 @@
 <div class="card-header">
   <div class="text-center actions">
-    <button tooltip="Save"
+    <button uib-tooltip="Save"
           class="btn btn-default"
           ng-click="saveRoute(route)"
           tooltip-placement="bottom"
           tooltip-animation="false">
       <i class="fa fa-check text-success fa-lg"></i>
     </button>
-    <button tooltip="Cancel"
+    <button uib-tooltip="Cancel"
           class="btn btn-default"
           ng-click="cancelEdit(route)"
           tooltip-placement="bottom"
@@ -37,9 +37,9 @@
           </div>
           <input placeholder="Grade" class="form-control" type="text" ng-model="route.grade">
         </div>
-        <rating ng-model="route.rating"
+        <uib-rating ng-model="route.rating"
                 state-on="'fa fa-star fa-lg'"
-                state-off="'fa fa-star-o fa-lg'"></rating>
+                state-off="'fa fa-star-o fa-lg'"></uib-rating>
 
         <div class="input-group">
           <div class="input-group-addon">
@@ -63,7 +63,7 @@
             <i class="fa fa-map-o fa-fw text-muted"></i>
           </div>
             <input placeholder="Sector"
-                   typeahead="sector for sector in sectors | filter:$viewValue"
+                   uib-typeahead="sector for sector in sectors | filter:$viewValue"
                    typeahead-on-select="sectorPopulatePlaceholder($item,route)"
                    class="form-control"
                    type="text"
@@ -103,7 +103,7 @@
                    class="form-control"
                    type="text"
                    ng-model="route.location"
-                   typeahead="location for location in locations | filter:$viewValue">
+                   uib-typeahead="location for location in locations | filter:$viewValue">
         </div>
 
       </div>
@@ -112,11 +112,11 @@
   <div class="back">
     <div class="content">
       <div class="main">
-        <tabset type="pills">
-        <tab>
-        <tab-heading>
+        <uib-tabset type="pills">
+        <uib-tab>
+        <uib-tab-heading>
         <span style="cursor:pointer"><i class="fa fa-pencil"></i> <span class="hidden-xs">Notes</span></span>
-        </tab-heading>
+        </uib-tab-heading>
 
         <div class="panel panel-default">
           <div class="panel-body">
@@ -129,24 +129,24 @@
             </span>
           </div>
         </div>
-        </tab>
+        </uib-tab>
 
-        <tab>
-        <tab-heading>
+        <uib-tab>
+        <uib-tab-heading>
         <span style="cursor:pointer"><i class="fa fa-search"></i> <span class="hidden-xs">Preview</span></span>
-        </tab-heading>
+        </uib-tab-heading>
 
         <div class="panel panel-default">
           <div class="panel-body">
             <div marked="route.notes"></div>
           </div>
         </div>
-        </tab>
+        </uib-tab>
 
-        <tab>
-        <tab-heading>
+        <uib-tab>
+        <uib-tab-heading>
         <span style="cursor:pointer"><i class="fa fa-question-circle"></i> <span class="hidden-xs">Help</span></span>
-        </tab-heading>
+        </uib-tab-heading>
 
         <div class="panel panel-default">
           <div class="panel-body">
@@ -156,9 +156,9 @@
               src="'views/_markdownReferenceSummary.html'"></div>
           </div>
         </div>
-        </tab>
+        </uib-tab>
 
-        </tabset>
+        </uib-tabset>
       </div>
     </div>
   </div> <!-- end back panel -->

--- a/app/views/_cardRoute.html
+++ b/app/views/_cardRoute.html
@@ -1,21 +1,21 @@
 <div class="e2e-route">
   <div class="card-header">
     <div class="text-center actions">
-      <button tooltip="Edit"
+      <button uib-tooltip="Edit"
         ng-click="editRoute(route)"
         tooltip-placement="bottom"
         class="btn btn-default e2e-edit"
         tooltip-animation="false">
         <i class="fa fa-pencil text-info fa-lg"></i>
       </button>
-      <button tooltip="Duplicate"
+      <button uib-tooltip="Duplicate"
         ng-click="copyRoute(route)"
         class="btn btn-default e2e-duplicate"
         tooltip-placement="bottom"
         tooltip-animation="false">
         <i class="fa fa-files-o text-success fa-lg"></i>
       </button>
-      <button tooltip="Delete"
+      <button uib-tooltip="Delete"
         ng-click="deleteRoute(route)"
         tooltip-placement="bottom"
         class="btn btn-default e2e-delete"
@@ -29,14 +29,14 @@
     <div class="front">
       <div class="content">
         <div class="main">
-          <span class="fa-stack fa-3x" tooltip="{{getIndoorLabel(route)}} {{route.type}}" tooltip-placement="bottom">
+          <span class="fa-stack fa-3x" uib-tooltip="{{getIndoorLabel(route)}} {{route.type}}" tooltip-placement="bottom">
             <i class="fa fa-circle fa-stack-2x" style="color:{{getTypeColor(route)}}"></i>
             <i class="fa {{getIconRock(route)}} fa-stack-1x fa-inverse"></i>
           </span>
           <h3 class="name">
             <i class="fa fa-eye" ng-show="route.watch"></i>
             {{ route.name }}
-            <i ng-if="route.$sync" class="fa fa-refresh text-info" tooltip="Offline {{route.$sync}}"></i>
+            <i ng-if="route.$sync" class="fa fa-refresh text-info" uib-tooltip="Offline {{route.$sync}}"></i>
           </h3>
           <div class="header">
             <span>- {{ route.grade }} -</span>

--- a/app/views/_mainNavbar.html
+++ b/app/views/_mainNavbar.html
@@ -1,4 +1,4 @@
-<div class="main-navbar">
+:armponent<div class="main-navbar">
   <div class="navbar navbar-default navbar-fixed-top" ng-controller="navbarCtrl">
     <div class="container">
       <div class="navbar-header">
@@ -42,7 +42,7 @@
             <div class="input-group-addon e2e-bucket">
               <button class="btn btn-success"
                       ng-click="getBucket()"
-                      tooltip="Get Bucket"
+                      uib-tooltip="Get Bucket"
                       tooltip-placement="left">
                 <i class="fa fa-sign-in"></i>
               </button>

--- a/app/views/_sliderCharts.html
+++ b/app/views/_sliderCharts.html
@@ -1,6 +1,6 @@
 <div class="slider-unstyled slider-charts">
-  <carousel>
-  <slide ng-repeat="slide in slides" active="slide.active">
+  <uib-carousel>
+  <uib-slide ng-repeat="slide in slides" active="slide.active">
   <div class="panel panel-success panel-unstyled">
     <div class="panel-heading">
       <h3 class="panel-title"><span class="fa {{slide.icon}}"></span> {{slide.title}}</h3>
@@ -9,6 +9,6 @@
       <div class="chart-{{slide.type}}"></div>
     </div>
   </div>
-  </slide>
-  </carousel>
+  </uib-slide>
+  </uib-carousel>
 </div>

--- a/app/views/sliderModal.html
+++ b/app/views/sliderModal.html
@@ -1,8 +1,8 @@
 <div class="modal-unstyled slider-unstyled">
   <div class="modal-body">
     <div>
-      <carousel interval="myInterval" no-wrap="noWrapSlides">
-      <slide ng-repeat="slide in slides" active="slide.active">
+      <uib-carousel interval="myInterval" no-wrap="noWrapSlides">
+      <uib-slide ng-repeat="slide in slides" active="slide.active">
 
       <div class="card-container manual-flip"
            ng-class="{hover: slide.$hover}"
@@ -12,8 +12,8 @@
            <ng-include ng-if="route.$editMode" src="'views/_cardAddRoute.html'"></ng-include>
       </div>
 
-      </slide>
-      </carousel>
+      </uib-slide>
+      </uib-carousel>
     </div>
   </div>
 

--- a/app/views/table.html
+++ b/app/views/table.html
@@ -7,7 +7,7 @@
 	<div class="panel-body">
 
     <p class="hidden-xs">
-      <button tooltip="Add route" class="btn btn-fab btn-raised btn-success" ng-click="tableVm.addRoute()"><i class="fa fa-plus"></i></button>
+      <button uib-tooltip="Add route" class="btn btn-fab btn-raised btn-success" ng-click="tableVm.addRoute()"><i class="fa fa-plus"></i></button>
     </p>
 
     <div ng-swipe-left="tableVm.nextPage()" ng-swipe-right="tableVm.previousPage()">
@@ -32,13 +32,13 @@
               <a title="Route Details">
                 {{route.name}}
               </a>
-                <i ng-if="route.$sync" class="fa fa-refresh text-info" tooltip="Offline {{route.$sync}}"></i>
+                <i ng-if="route.$sync" class="fa fa-refresh text-info" uib-tooltip="Offline {{route.$sync}}"></i>
             </td>
             <td class="">
               <span>{{route.grade}}</span>
             </td>
             <td class="hidden-xs hidden-sm">
-              <rating readonly="true" ng-model="route.rating"></rating>
+              <uib-rating readonly="true" ng-model="route.rating"></uib-rating>
             </td>
             <td class="hidden-xs">
               <span>{{route.status}}</span>

--- a/app/views/timeline.html
+++ b/app/views/timeline.html
@@ -5,7 +5,7 @@
 
   <div class="panel-body">
     <p class="text-center climb-add">
-      <button tooltip="Add new route"
+      <button uib-tooltip="Add new route"
               class="btn btn-fab btn-raised btn-success"
               ng-click="timelineVm.addRoute()">
         <i class="fa fa-plus"></i>
@@ -15,7 +15,7 @@
     <timeline>
       <timeline-event ng-repeat="event in timelineVm.events">
       <timeline-badge style="background-color:{{ timelineVm.getTypeColor(event) }}"
-      tooltip="{{ timelineVm.getBadgeTooltip(event) }}">
+      uib-tooltip="{{ timelineVm.getBadgeTooltip(event) }}">
           <i class="fa {{ timelineVm.getBadgeIcon(event) }}"></i>
         </timeline-badge>
 
@@ -45,7 +45,7 @@
               <a style="cursor:pointer" title="Route Details" ng-click="timelineVm.openRouteModal(route, routes)">
                 {{route.name}}
               </a>
-              <i ng-if="route.$sync" class="fa fa-refresh text-info" tooltip="Offline {{route.$sync}}"></i>
+              <i ng-if="route.$sync" class="fa fa-refresh text-info" uib-tooltip="Offline {{route.$sync}}"></i>
               <br>
             </span>
           </div>

--- a/test/unit/controllers/modaladdroute.js
+++ b/test/unit/controllers/modaladdroute.js
@@ -42,7 +42,7 @@ describe('Controller: ModaladdrouteCtrl', function() {
 
     ModaladdrouteCtrl = $controller('ModaladdrouteCtrl', {
       $scope:          scope,
-      $modalInstance:  modalInstance,
+      $uibModalInstance:  modalInstance,
       utilsRouteSvc:   utilsRouteSvc,
       utilsChartSvc:   utilsChartSvc
     })

--- a/test/unit/controllers/modalslider.js
+++ b/test/unit/controllers/modalslider.js
@@ -57,7 +57,7 @@ describe('Controller: ModalsliderCtrl', function() {
 
     ModalsliderCtrl = $controller('ModalsliderCtrl', {
       $scope:                     scope,
-      $modalInstance:             modalInstance,
+      $uibModalInstance:             modalInstance,
       routesId:                   routesId,
       routeNoteFormattingFilter:  filters.routeNoteFormattingFilter,
       utilsChartSvc:              utilsChartSvc,

--- a/test/unit/controllers/tableCtrl.js
+++ b/test/unit/controllers/tableCtrl.js
@@ -34,7 +34,7 @@ describe('Controller: tableCtrl', function() {
 
     tableCtrl = $controller('tableCtrl as tableVm', {
       $scope:         scope,
-      $modal:         modal,
+      $uibModal:         modal,
       utilsRouteSvc:  utilsRouteSvc,
       utilsChartSvc:  utilsChartSvc
     })

--- a/test/unit/controllers/timeline.js
+++ b/test/unit/controllers/timeline.js
@@ -50,7 +50,7 @@ describe('Controller: TimelineCtrl', function() {
       $rootScope:     rootScope,
       utilsChartSvc:  utilsChartSvc,
       utilsRouteSvc:  utilsRouteSvc,
-      $modal:         modal
+      $uibModal:         modal
     })
   }))
 


### PR DESCRIPTION
**Problem**
The version of UI bootstrap library was previously updated but the
console log shows warning about deprecated components name.

**Solution**
* :arrow_up: Migrate UIB $modal component
* :arrow_up: Upgrade UIB rating component
* :arrow_up: Upgrade UIB tooltip component
* :arrow_up: Upgrade UIB slide and carousel
* :arrow_up: Upgrade UIB modalInstance component
* :arrow_up: Upgrade UIB tab, tab-set, tab-heading components
* :arrow_up: Upgrade UIB typeahead component

**Result**
No warning are displayed on the console log related to UI bootstrap
library.