### PR TITLE
Fix timeline date order

### DIFF
--- a/app/scripts/services/timeline.js
+++ b/app/scripts/services/timeline.js
@@ -59,8 +59,8 @@
 
       // Calculate first/last date per locations
       locations = _.map(locations, function(areaLocation) {
-        areaLocation.start = _.first(areaLocation.routes).date
-        areaLocation.end   = _.last(areaLocation.routes).date
+        areaLocation.end = _.first(areaLocation.routes).date
+        areaLocation.start   = _.last(areaLocation.routes).date
         return areaLocation
       })
 

--- a/test/unit/services/timeline.js
+++ b/test/unit/services/timeline.js
@@ -58,8 +58,8 @@ describe('Service: timelineSvc', function() {
                 }
               ]
             ],
-            "start": "08/18/2015",
-            "end": "08/02/2015"
+            "end": "08/18/2015",
+            "start": "08/02/2015"
           }
         },
         {
@@ -78,8 +78,8 @@ describe('Service: timelineSvc', function() {
                 }
               ]
             ],
-            "start": "07/20/2015",
-            "end": "07/08/2015"
+            "end": "07/20/2015",
+            "start": "07/08/2015"
           }
         }
       ]


### PR DESCRIPTION
**Problem**
https://github.com/10alab/Siurana/issues/1

The dates from/to on the timeline for each sectors are not sorted.

**Solution**
Change timeline service process data to set `end` date as `first` value
of the array, and respectively for `start`

**Result**
Timeline dates for sector routes are sorted