### PR TITLE
Reduce size of build file

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,555 +1,54 @@
-// Generated on 2015-07-26 using generator-angular 0.12.1
 'use strict'
 
 module.exports = function(grunt) {
-
   // Time how long tasks take. Can help when optimizing build times
   require('time-grunt')(grunt)
 
   // Automatically load required Grunt tasks
-  require('jit-grunt')(grunt, {
-    useminPrepare: 'grunt-usemin',
-    ngtemplates: 'grunt-angular-templates',
-    cdnify: 'grunt-google-cdn',
-    coveralls: 'grunt-karma-coveralls',
-    jsdoc: 'grunt-jsdoc',
-    protractor: 'grunt-protractor-runner'
-  })
-
-  // Configurable paths for the application
-  var appConfig = {
-    app: require('./bower.json').appPath || 'app',
-    dist: 'dist'
-  }
-
-  // Define the configuration for all the tasks
-  grunt.initConfig({
-
-    // Project settings
-    yeoman: appConfig,
-
-    // Watches files for changes and runs tasks based on the changed files
-    watch: {
-      bower: {
-        files: ['bower.json'],
-        tasks: ['wiredep']
+  var config = require('load-grunt-config')(grunt, {
+		data: {
+      path: {
+        app: 'app',
+        dist: 'dist',
+        test: 'test',
+        doc: 'dist/doc',
+        karmaConf: 'test/karma.conf.js'
       },
-      js: {
-        files: [
-          '<%= yeoman.app %>/scripts/**/*.js',
-          '<%= yeoman.app %>/components/**/*.js'
-        ],
-        tasks: ['newer:jshint:all', 'newer:jscs'],
-        options: {
-          livereload: '<%= connect.options.livereload %>'
-        }
-      },
-      jsTest: {
-        files: ['test/unit/**/*.js'],
-        tasks: ['newer:jshint:test', 'newer:jscs', 'karma']
-      },
-      compass: {
-        files: ['<%= yeoman.app %>/styles/**/*.{scss,sass}'],
-        tasks: ['compass:server', 'autoprefixer:server']
-      },
-      gruntfile: {
-        files: ['Gruntfile.js']
-      },
-      livereload: {
-        options: {
-          livereload: '<%= connect.options.livereload %>'
-        },
-        files: [
-          '<%= yeoman.app %>/**/*.html',
-          '.tmp/styles/**/*.css',
-          '<%= yeoman.app %>/images/**/*.{png,jpg,jpeg,gif,webp,svg}'
-        ]
-      }
-    },
-
-    jsdoc: {
-      dist: {
-        src: [
-          'app/scripts/**/*.js',
-          'app/components/**/*.js'
-        ],
-        options: {
-          destination: appConfig.dist + '/doc',
-          readme: 'README.md',
-          template: 'node_modules/ink-docstrap/template',
-          configure: 'jsdoc.conf.json'
-        }
-      }
-    },
-
-    // The actual grunt server settings
-    connect: {
       options: {
         port: 9000,
-        // Change this to '0.0.0.0' to access the server from outside.
         hostname: 'localhost',
-        livereload: 35729
-      },
-      livereload: {
-        options: {
-          open: true,
-          middleware: function(connect) {
-            return [
-              connect.static('.tmp'),
-              connect().use(
-                '/bower_components',
-                connect.static('./bower_components')
-              ),
-              connect().use(
-                '/app/styles',
-                connect.static('./app/styles')
-              ),
-              connect.static(appConfig.app)
-            ]
-          }
-        }
-      },
-      test: {
-        options: {
-          port: 9001,
-          middleware: function(connect) {
-            return [
-              connect.static('.tmp'),
-              connect.static('test'),
-              connect().use(
-                '/bower_components',
-                connect.static('./bower_components')
-              ),
-              connect.static(appConfig.app)
-            ]
-          }
-        }
-      },
-      dist: {
-        options: {
-          open: true,
-          base: '<%= yeoman.dist %>'
-        }
-      }
-    },
-
-    // Make sure code styles are up to par and there are no obvious mistakes
-    jshint: {
-      options: {
-        jshintrc: '.jshintrc',
-        reporter: require('jshint-stylish')
-      },
-      all: {
-        src: [
-          'Gruntfile.js',
-          '<%= yeoman.app %>/components/**/*.js',
-          '<%= yeoman.app %>/scripts/**/*.js'
-        ]
-      },
-      test: {
-        options: {
-          jshintrc: '.jshintrc'
-        },
-        src: ['test/**/*.js']
-      }
-    },
-
-    jscs: {
-      src: [
-        'Gruntfile.js',
-        '<%= yeoman.app %>/components/**/*.js',
-        '<%= yeoman.app %>/scripts/**/*.js',
-        'test/**/*.js'
-      ],
-      options: {
-        config: '.jscsrc'
-      }
-    },
-
-    versioncheck: {
-      options: {
-        hideUpToDate: false
-      }
-    },
-
-    // Empties folders to start fresh
-    clean: {
-      dist: {
-        files: [{
-          dot: true,
-          src: [
-            '.tmp',
-            '<%= yeoman.dist %>/**/*',
-            '!<%= yeoman.dist %>/.git**/*'
-          ]
-        }]
-      },
-      server: '.tmp'
-    },
-
-    // Add vendor prefixed styles
-    autoprefixer: {
-      options: {
-        browsers: ['last 1 version']
-      },
-      server: {
-        options: {
-          map: true
-        },
-        files: [{
-          expand: true,
-          cwd: '.tmp/styles/',
-          src: '**/*.css',
-          dest: '.tmp/styles/'
-        }]
-      },
-      dist: {
-        files: [{
-          expand: true,
-          cwd: '.tmp/styles/',
-          src: '**/*.css',
-          dest: '.tmp/styles/'
-        }]
-      }
-    },
-
-    // Automatically inject Bower components into the app
-    wiredep: {
-      app: {
-        src: ['<%= yeoman.app %>/index.html'],
-        ignorePath:  /\.\.\//
-      },
-      test: {
-        devDependencies: true,
-        src: '<%= karma.unit.configFile %>',
-        ignorePath:  /\.\.\//,
-        fileTypes:{
-          js: {
-            block: /(([\s\t]*)\/{2}\s*?bower:\s*?(\S*))(\n|\r|.)*?(\/{2}\s*endbower)/gi,
-              detect: {
-                js: /'(.*\.js)'/gi
-              },
-              replace: {
-                js: '\'{{filePath}}\','
-              }
-            }
-          }
-      },
-      sass: {
-        src: ['<%= yeoman.app %>/styles/**/*.{scss,sass}'],
-        ignorePath: /(\.\.\/){1,2}bower_components\//
-      }
-    },
-
-    // Compiles Sass to CSS and generates necessary files if requested
-    compass: {
-      options: {
-        sassDir: '<%= yeoman.app %>/styles',
-        cssDir: '.tmp/styles',
-        generatedImagesDir: '.tmp/images/generated',
-        imagesDir: '<%= yeoman.app %>/images',
-        javascriptsDir: '<%= yeoman.app %>/scripts',
-        fontsDir: '<%= yeoman.app %>/styles/fonts',
-        importPath: './bower_components',
-        httpImagesPath: '/images',
-        httpGeneratedImagesPath: '/images/generated',
-        httpFontsPath: '/styles/fonts',
-        relativeAssets: false,
-        assetCacheBuster: false,
-        raw: 'Sass::Script::Number.precision = 10\n'
-      },
-      dist: {
-        options: {
-          generatedImagesDir: '<%= yeoman.dist %>/images/generated'
-        }
-      },
-      server: {
-        options: {
-          sourcemap: true
-        }
-      }
-    },
-
-    // Renames files for browser caching purposes
-    filerev: {
-      dist: {
-        src: [
-          '<%= yeoman.dist %>/scripts/**/*.js',
-          '<%= yeoman.dist %>/components/**/*.js',
-          '<%= yeoman.dist %>/styles/**/*.css',
-          '<%= yeoman.dist %>/images/**/*.{png,jpg,jpeg,gif,webp,svg}',
-          '<%= yeoman.dist %>/styles/fonts/*'
-        ]
-      }
-    },
-
-    // Reads HTML for usemin blocks to enable smart builds that automatically
-    // concat, minify and revision files. Creates configurations in memory so
-    // additional tasks can operate on them
-    useminPrepare: {
-      html: '<%= yeoman.app %>/index.html',
-      options: {
-        dest: '<%= yeoman.dist %>',
-        flow: {
-          html: {
-            steps: {
-              js: ['concat'],
-              css: ['cssmin']
-            },
-            post: {}
-          }
-        }
-      }
-    },
-
-    // Performs rewrites based on filerev and the useminPrepare configuration
-    usemin: {
-      html: ['<%= yeoman.dist %>/**/*.html'],
-      css: ['<%= yeoman.dist %>/styles/**/*.css'],
-      js: [
-        '<%= yeoman.dist %>/scripts/**/*.js',
-        '<%= yeoman.dist %>/components/**/*.js'
-      ],
-      options: {
-        assetsDirs: [
-          '<%= yeoman.dist %>',
-          '<%= yeoman.dist %>/images',
-          '<%= yeoman.dist %>/styles'
-        ],
-        patterns: {
-          js: [[/(images\/[^''""]*\.(png|jpg|jpeg|gif|webp|svg))/g,
-          'Replacing references to images']]
-        }
-      }
-    },
-
-    // The following *-min tasks will produce minified files in the dist folder
-    // By default, your `index.html`'s <!-- Usemin block --> will take care of
-    // minification. These next options are pre-configured if you do not wish
-    // to use the Usemin blocks.
-    cssmin: {
-      dist: {
-        files: {
-          '<%= yeoman.dist %>/styles/main.css': [
-            '.tmp/styles/**/*.css'
-          ]
-        }
-      }
-    },
-    // uglify: {
-    //   dist: {
-    //     files: {
-    //       '<%= yeoman.dist %>/scripts/scripts.js': [
-    //         '<%= yeoman.dist %>/scripts/scripts.js'
-    //       ]
-    //     }
-    //   }
-    // },
-    concat: {
-      dist: {}
-    },
-
-    imagemin: {
-      dist: {
-        files: [{
-          expand: true,
-          cwd: '<%= yeoman.app %>/images',
-          src: '**/*.{png,jpg,jpeg,gif}',
-          dest: '<%= yeoman.dist %>/images'
-        }]
-      }
-    },
-
-    svgmin: {
-      dist: {
-        files: [{
-          expand: true,
-          cwd: '<%= yeoman.app %>/images',
-          src: '**/*.svg',
-          dest: '<%= yeoman.dist %>/images'
-        }]
-      }
-    },
-
-    htmlmin: {
-      dist: {
-        options: {
+        livereload: 35729,
+        htmlmin: {
           collapseWhitespace: true,
           conservativeCollapse: true,
           collapseBooleanAttributes: true,
           removeCommentsFromCDATA: true
-        },
-        files: [{
-          expand: true,
-          cwd: '<%= yeoman.dist %>',
-          src: ['*.html'],
-          dest: '<%= yeoman.dist %>'
-        }]
-      }
-    },
-
-    ngtemplates: {
-      dist: {
-        options: {
-          module: 'climbingMemo',
-          htmlmin: '<%= htmlmin.dist.options %>',
-          usemin: 'scripts/scripts.js'
-        },
-        cwd: '<%= yeoman.app %>',
-        src: 'views/**/*.html',
-        dest: '.tmp/templateCache.js'
-      }
-    },
-
-    // ng-annotate tries to make the code safe for minification automatically
-    // by using the Angular long form for dependency injection.
-    ngAnnotate: {
-      dist: {
-        files: [{
-          expand: true,
-          cwd: '.tmp/concat/scripts',
-          src: '*.js',
-          dest: '.tmp/concat/scripts'
-        }]
-      }
-    },
-
-    // Replace Google CDN references
-    cdnify: {
-      dist: {
-        html: ['<%= yeoman.dist %>/*.html']
-      }
-    },
-
-    // Copies remaining files to places other tasks can use
-    copy: {
-      dist: {
-        files: [{
-          expand: true,
-          dot: true,
-          cwd: '<%= yeoman.app %>',
-          dest: '<%= yeoman.dist %>',
-          src: [
-            '*.{ico,png,txt}',
-            '**/*.js',
-            '**/*.html',
-            'images/**/*.{webp}',
-            'styles/fonts/**/*.*'
-          ]
-        }, {
-          expand: true,
-          cwd: '.tmp/images',
-          dest: '<%= yeoman.dist %>/images',
-          src: ['generated/*']
-        }, {
-          expand: true,
-          cwd: 'bower_components/bootstrap/dist',
-          src: 'fonts/*',
-          dest: '<%= yeoman.dist %>'
-        }, {
-          expand: true,
-          cwd: 'bower_components/components-font-awesome',
-          src: 'fonts/*',
-          dest: '<%= yeoman.dist %>'
-        }]
-      },
-      styles: {
-        expand: true,
-        cwd: '<%= yeoman.app %>/styles',
-        dest: '.tmp/styles/',
-        src: '**/*.css'
-      }
-    },
-
-    manifest: {
-      generate: {
-        options: {
-          basePath: '<%= yeoman.dist %>',
-          cache: [
-            'index.html',
-            'fonts/glyphicons-halflings-regular.woff2',
-            'fonts/glyphicons-halflings-regular.woff',
-            'fonts/glyphicons-halflings-regular.ttf',
-            'fonts/fontawesome-webfont.ttf?v=4.4.0',
-            'fonts/fontawesome-webfont.woff?v=4.4.0',
-            'fonts/fontawesome-webfont.woff2?v=4.4.0',
-            'styles/main.css',
-            'styles/vendor.css',
-            'scripts/vendor.js ',
-            'scripts/scripts.js'
-          ],
-          network: ['*'],
-          fallback: ['/ /offline.html'],
-          exclude: ['manifest.appcache'],
-          preferOnline: true,
-          verbose: true,
-          timestamp: true,
-          hash: true,
-          master: ['index.html']
-        },
-        src: [
-          'components/**/*.js',
-          'scripts/**/*.js',
-          'styles/**/*.css',
-          'views/**/*.html'
-        ],
-        dest: 'manifest.appcache'
-      }
-    },
-
-    // Run some tasks in parallel to speed up the build process
-    concurrent: {
-      server: [
-        'compass:server'
-      ],
-      test: [
-        'compass'
-      ],
-      dist: [
-        'compass:dist',
-        'imagemin',
-        'svgmin'
-      ]
-    },
-
-    // Test settings
-    karma: {
-      unit: {
-        configFile: 'test/karma.conf.js',
-        singleRun: true
-      }
-    },
-
-    protractor: {
-      options: {
-        keepAlive: false,
-        noColor: false
-      },
-      local: {
-        options: {
-          configFile: 'test/e2e/protractor.conf.js'
-        }
-      },
-      sauceLab: {
-        options: {
-          configFile: 'test/e2e/protractorSauceLab.conf.js',
-          args: {
-            sauceUser: process.env.SAUCE_USERNAME,
-            sauceKey: process.env.SAUCE_ACCESS_KEY
-          }
         }
       }
     },
-
-    coveralls: {
-      options: {
-        coverageDir: 'coverage',
-        force: true,
-        recursive: true
+    jitGrunt: {
+      staticMappings: {
+        useminPrepare: 'grunt-usemin',
+        ngtemplates: 'grunt-angular-templates',
+        cdnify: 'grunt-google-cdn',
+        coveralls: 'grunt-karma-coveralls',
+        protractor: 'grunt-protractor-runner',
+        versioncheck: 'grunt-version-check'
       }
     }
   })
 
+  // config.uglify = {
+  //   dist: {
+  //     files: {
+  //       'dist/scripts/scripts.js': [
+  //         'dist/scripts/scripts.js'
+  //       ]
+  //     }
+  //   }
+  // }
+
+  grunt.initConfig(config)
 
   grunt.registerTask('serve', 'Compile then start a connect web server', function(target) {
     if (target === 'dist') {
@@ -566,11 +65,6 @@ module.exports = function(grunt) {
     ])
   })
 
-  grunt.registerTask('server', 'DEPRECATED TASK. Use the "serve" task instead', function(target) {
-    grunt.log.warn('The `server` task has been deprecated. Use `grunt serve` to start a server.')
-    grunt.task.run(['serve:' + target])
-  })
-
   grunt.registerTask('help', 'Display some helpful information if no task provided', function() {
     this.async()
     grunt.util.spawn({
@@ -578,61 +72,4 @@ module.exports = function(grunt) {
         grunt.log.writelns(r, '\n')
       })
   })
-
-  grunt.registerTask('e2e-test', [
-    'connect:test',
-    'protractor:local'
-  ])
-
-  grunt.registerTask('unit-test', [
-    'jscs',
-    'jshint',
-    'karma',
-    'coveralls'
-  ])
-
-  grunt.registerTask('full-test', [
-    'clean:server',
-    'wiredep',
-    'concurrent:test',
-    'autoprefixer',
-    'unit-test',
-    'connect:test',
-    'protractor:sauceLab'
-  ])
-
-  grunt.registerTask('test', [
-    'clean:server',
-    'wiredep',
-    'concurrent:test',
-    'autoprefixer',
-    'unit-test',
-    'e2e-test'
-  ])
-
-  grunt.registerTask('build', [
-    'clean:dist',
-    'wiredep',
-    'useminPrepare',
-    'concurrent:dist',
-    'autoprefixer',
-    'ngtemplates',
-    'concat',
-    'ngAnnotate',
-    'copy:dist',
-    'cdnify',
-    'cssmin',
-    // 'uglify',
-    // 'filerev',
-    'usemin',
-    'htmlmin',
-    'manifest'
-  ])
-
-  grunt.registerTask('default', [
-    'newer:jshint',
-    'newer:jscs',
-    'test',
-    'build'
-  ])
 }

--- a/grunt/aliases.js
+++ b/grunt/aliases.js
@@ -1,0 +1,53 @@
+module.exports = {
+  'default': [
+    'newer:jshint',
+    'newer:jscs',
+    'test',
+    'build'
+  ],
+  'test': [
+    'clean:server',
+    'wiredep',
+    'concurrent:test',
+    'autoprefixer',
+    'unit-test',
+    'e2e-test'
+  ],
+  'e2e-test': [
+    'connect:test',
+    'protractor:local'
+  ],
+  'unit-test': [
+    'jscs',
+    'jshint',
+    'karma',
+    'coveralls'
+  ],
+  'full-test': [
+    'clean:server',
+    'wiredep',
+    'concurrent:test',
+    'autoprefixer',
+    'unit-test',
+    'connect:test',
+    'protractor:sauceLab'
+  ],
+  'build': [
+    'clean:dist',
+    'wiredep',
+    'useminPrepare',
+    'concurrent:dist',
+    'autoprefixer',
+    'ngtemplates',
+    'concat',
+    'ngAnnotate',
+    'copy:dist',
+    'cdnify',
+    'cssmin',
+    // 'uglify',
+    // 'filerev',
+    'usemin',
+    'htmlmin',
+    'manifest'
+  ]
+}

--- a/grunt/autoprefixer.js
+++ b/grunt/autoprefixer.js
@@ -1,0 +1,24 @@
+module.exports = {
+  options: {
+    browsers: ['last 1 version']
+  },
+  server: {
+    options: {
+      map: true
+    },
+    files: [{
+      expand: true,
+      cwd: '.tmp/styles/',
+      src: '**/*.css',
+      dest: '.tmp/styles/'
+    }]
+  },
+  dist: {
+    files: [{
+      expand: true,
+      cwd: '.tmp/styles/',
+      src: '**/*.css',
+      dest: '.tmp/styles/'
+    }]
+  }
+}

--- a/grunt/cdnify.js
+++ b/grunt/cdnify.js
@@ -1,0 +1,5 @@
+module.exports = {
+  dist: {
+    html: ['dist/*.html']
+  }
+}

--- a/grunt/clean.js
+++ b/grunt/clean.js
@@ -1,0 +1,13 @@
+module.exports = {
+  dist: {
+    files: [{
+      dot: true,
+      src: [
+        '.tmp',
+        '<%= path.dist %>/**/*',
+        '!<%= path.dist %>/.git**/*'
+      ]
+    }]
+  },
+  server: '.tmp'
+}

--- a/grunt/compass.js
+++ b/grunt/compass.js
@@ -1,0 +1,27 @@
+module.exports = {
+  options: {
+    sassDir: '<%= path.app %>/styles',
+    cssDir: '.tmp/styles',
+    generatedImagesDir: '.tmp/images/generated',
+    imagesDir: '<%= path.app %>/images',
+    javascriptsDir: '<%= path.app %>/scripts',
+    fontsDir: '<%= path.app %>/styles/fonts',
+    importPath: './bower_components',
+    httpImagesPath: '/images',
+    httpGeneratedImagesPath: '/images/generated',
+    httpFontsPath: '/styles/fonts',
+    relativeAssets: false,
+    assetCacheBuster: false,
+    raw: 'Sass::Script::Number.precision = 10\n'
+  },
+  dist: {
+    options: {
+      generatedImagesDir: '<%= path.dist %>/images/generated'
+    }
+  },
+  server: {
+    options: {
+      sourcemap: true
+    }
+  }
+}

--- a/grunt/concat.js
+++ b/grunt/concat.js
@@ -1,0 +1,3 @@
+module.exports = {
+  dist: {}
+}

--- a/grunt/concurrent.js
+++ b/grunt/concurrent.js
@@ -1,0 +1,13 @@
+module.exports = {
+  server: [
+    'compass:server'
+  ],
+  test: [
+    'compass'
+  ],
+  dist: [
+    'compass:dist',
+    'imagemin',
+    'svgmin'
+  ]
+}

--- a/grunt/connect.js
+++ b/grunt/connect.js
@@ -1,0 +1,48 @@
+module.exports = {
+  options: {
+    port: '<%= options.port %>',
+    hostname: '<%= options.hostname %>',
+    livereload: '<%= options.livereload %>'
+  },
+  livereload: {
+    options: {
+      open: true,
+      middleware: function(connect) {
+        return [
+          connect.static('.tmp'),
+          connect().use(
+            '/bower_components',
+            connect.static('./bower_components')
+          ),
+          connect().use(
+            '/app/styles',
+            connect.static('./app/styles')
+          ),
+          connect.static('app')
+        ]
+      }
+    }
+  },
+  test: {
+    options: {
+      port: 9001,
+      middleware: function(connect) {
+        return [
+          connect.static('.tmp'),
+          connect.static('test'),
+          connect().use(
+            '/bower_components',
+            connect.static('./bower_components')
+          ),
+          connect.static('app')
+        ]
+      }
+    }
+  },
+  dist: {
+    options: {
+      open: true,
+      base: '<%= path.dist %>'
+    }
+  }
+}

--- a/grunt/copy.js
+++ b/grunt/copy.js
@@ -1,0 +1,38 @@
+module.exports = {
+  dist: {
+    files: [{
+      expand: true,
+      dot: true,
+      cwd: '<%= path.app %>',
+      dest: '<%= path.dist %>',
+      src: [
+        '*.{ico,png,txt}',
+        '**/*.js',
+        '**/*.html',
+        'images/**/*.{webp}',
+        'styles/fonts/**/*.*'
+      ]
+    }, {
+      expand: true,
+      cwd: '.tmp/images',
+      dest: '<%= path.dist %>/images',
+      src: ['generated/*']
+    }, {
+      expand: true,
+      cwd: 'bower_components/bootstrap/dist',
+      src: 'fonts/*',
+      dest: '<%= path.dist %>'
+    }, {
+      expand: true,
+      cwd: 'bower_components/components-font-awesome',
+      src: 'fonts/*',
+      dest: '<%= path.dist %>'
+    }]
+  },
+  styles: {
+    expand: true,
+    cwd: '<%= path.app %>/styles',
+    dest: '.tmp/styles/',
+    src: '**/*.css'
+  }
+}

--- a/grunt/coveralls.js
+++ b/grunt/coveralls.js
@@ -1,0 +1,7 @@
+module.exports = {
+  options: {
+    coverageDir: 'coverage',
+    force: true,
+    recursive: true
+  }
+}

--- a/grunt/cssmin.js
+++ b/grunt/cssmin.js
@@ -1,0 +1,9 @@
+module.exports = {
+  dist: {
+    files: {
+      '<%= path.dist %>/styles/main.css': [
+        '.tmp/styles/**/*.css'
+      ]
+    }
+  }
+}

--- a/grunt/filerev.js
+++ b/grunt/filerev.js
@@ -1,0 +1,11 @@
+module.exports = {
+  dist: {
+    src: [
+      '<%= path.dist %>/scripts/**/*.js',
+      '<%= path.dist %>/components/**/*.js',
+      '<%= path.dist %>/styles/**/*.css',
+      '<%= path.dist %>/images/**/*.{png,jpg,jpeg,gif,webp,svg}',
+      '<%= path.dist %>/styles/fonts/*'
+    ]
+  }
+}

--- a/grunt/htmlmin.js
+++ b/grunt/htmlmin.js
@@ -1,0 +1,16 @@
+module.exports = {
+  dist: {
+    options: {
+      collapseWhitespace: true,
+      conservativeCollapse: true,
+      collapseBooleanAttributes: true,
+      removeCommentsFromCDATA: true
+    },
+    files: [{
+      expand: true,
+      cwd: '<%= path.dist %>',
+      src: ['*.html'],
+      dest: '<%= path.dist %>'
+    }]
+  }
+}

--- a/grunt/imagemin.js
+++ b/grunt/imagemin.js
@@ -1,0 +1,10 @@
+module.exports = {
+  dist: {
+    files: [{
+      expand: true,
+      cwd: '<%= path.app %>/images',
+      src: '**/*.{png,jpg,jpeg,gif}',
+      dest: '<%= path.dist %>/images'
+    }]
+  }
+}

--- a/grunt/jscs.js
+++ b/grunt/jscs.js
@@ -1,0 +1,11 @@
+module.exports = {
+  src: [
+    'Gruntfile.js',
+    '<%= path.app %>/components/**/*.js',
+    '<%= path.app %>/scripts/**/*.js',
+    '<%= path.test %>/**/*.js'
+  ],
+  options: {
+    config: '.jscsrc'
+  }
+}

--- a/grunt/jsdoc.js
+++ b/grunt/jsdoc.js
@@ -1,0 +1,14 @@
+module.exports = {
+  dist: {
+    src: [
+      '<%= path.app %>/scripts/**/*.js',
+      '<%= path.app %>/components/**/*.js'
+    ],
+    options: {
+      destination: 'dist/doc',
+      readme: 'README.md',
+      template: 'node_modules/ink-docstrap/template',
+      configure: 'jsdoc.conf.json'
+    }
+  }
+}

--- a/grunt/jshint.js
+++ b/grunt/jshint.js
@@ -1,0 +1,19 @@
+module.exports.tasks = {
+  options: {
+    jshintrc: '.jshintrc',
+    reporter: require('jshint-stylish')
+  },
+  all: {
+    src: [
+      'Gruntfile.js',
+      '<%= path.app %>/components/**/*.js',
+      '<%= path.app %>/scripts/**/*.js'
+    ]
+  },
+  test: {
+    options: {
+      jshintrc: '.jshintrc'
+    },
+    src: ['test/**/*.js']
+  }
+}

--- a/grunt/karma.js
+++ b/grunt/karma.js
@@ -1,0 +1,6 @@
+module.exports = {
+  unit: {
+    configFile: '<%= path.karmaConf %>',
+    singleRun: true
+  }
+}

--- a/grunt/manifest.js
+++ b/grunt/manifest.js
@@ -1,0 +1,35 @@
+module.exports = {
+  generate: {
+    options: {
+      basePath: '<%= path.dist %>',
+      cache: [
+        'index.html',
+        'fonts/glyphicons-halflings-regular.woff2',
+        'fonts/glyphicons-halflings-regular.woff',
+        'fonts/glyphicons-halflings-regular.ttf',
+        'fonts/fontawesome-webfont.ttf?v=4.4.0',
+        'fonts/fontawesome-webfont.woff?v=4.4.0',
+        'fonts/fontawesome-webfont.woff2?v=4.4.0',
+        'styles/main.css',
+        'styles/vendor.css',
+        'scripts/vendor.js ',
+        'scripts/scripts.js'
+      ],
+      network: ['*'],
+      fallback: ['/ /offline.html'],
+      exclude: ['manifest.appcache'],
+      preferOnline: true,
+      verbose: true,
+      timestamp: true,
+      hash: true,
+      master: ['index.html']
+    },
+    src: [
+      'components/**/*.js',
+      'scripts/**/*.js',
+      'styles/**/*.css',
+      'views/**/*.html'
+    ],
+    dest: 'manifest.appcache'
+  }
+}

--- a/grunt/ngAnnotate.js
+++ b/grunt/ngAnnotate.js
@@ -1,0 +1,10 @@
+module.exports = {
+  dist: {
+    files: [{
+      expand: true,
+      cwd: '.tmp/concat/scripts',
+      src: '*.js',
+      dest: '.tmp/concat/scripts'
+    }]
+  }
+}

--- a/grunt/ngtemplates.js
+++ b/grunt/ngtemplates.js
@@ -1,0 +1,12 @@
+module.exports = {
+  dist: {
+    options: {
+      module: 'climbingMemo',
+      htmlmin: '<%= options.htmlmin %>',
+      usemin: 'scripts/scripts.js'
+    },
+    cwd: 'app/',
+    src: 'views/**/*.html',
+    dest: '.tmp/templateCache.js'
+  }
+}

--- a/grunt/protractor.js
+++ b/grunt/protractor.js
@@ -1,0 +1,20 @@
+module.exports = {
+  options: {
+    keepAlive: false,
+    noColor: false
+  },
+  local: {
+    options: {
+      configFile: '<%= path.test %>/e2e/protractor.conf.js'
+    }
+  },
+  sauceLab: {
+    options: {
+      configFile: '<%= path.test %>/e2e/protractorSauceLab.conf.js',
+      args: {
+        sauceUser: process.env.SAUCE_USERNAME,
+        sauceKey: process.env.SAUCE_ACCESS_KEY
+      }
+    }
+  }
+}

--- a/grunt/svgmin.js
+++ b/grunt/svgmin.js
@@ -1,0 +1,10 @@
+module.exports = {
+  dist: {
+    files: [{
+      expand: true,
+      cwd: '<%= path.app %>/images',
+      src: '**/*.svg',
+      dest: '<%= path.dist %>/images'
+    }]
+  }
+}

--- a/grunt/usemin.js
+++ b/grunt/usemin.js
@@ -1,0 +1,19 @@
+module.exports = {
+  html: ['<%= path.dist %>/**/*.html'],
+  css: ['<%= path.dist %>/styles/**/*.css'],
+  js: [
+    '<%= path.dist %>/scripts/**/*.js',
+    '<%= path.dist %>/components/**/*.js'
+  ],
+  options: {
+    assetsDirs: [
+      '<%= path.dist %>',
+      '<%= path.dist %>/images',
+      '<%= path.dist %>/styles'
+    ],
+    patterns: {
+      js: [[/(images\/[^''""]*\.(png|jpg|jpeg|gif|webp|svg))/g,
+      'Replacing references to images']]
+    }
+  }
+}

--- a/grunt/useminPrepare.js
+++ b/grunt/useminPrepare.js
@@ -1,0 +1,15 @@
+module.exports = {
+  html: '<%= path.app %>/index.html',
+  options: {
+    dest: 'dist/',
+    flow: {
+      html: {
+        steps: {
+          js: ['concat'],
+          css: ['cssmin']
+        },
+        post: {}
+      }
+    }
+  }
+}

--- a/grunt/versioncheck.js
+++ b/grunt/versioncheck.js
@@ -1,0 +1,5 @@
+module.exports = {
+  options: {
+    hideUpToDate: false
+  }
+}

--- a/grunt/watch.js
+++ b/grunt/watch.js
@@ -1,0 +1,37 @@
+module.exports = {
+  bower: {
+    files: ['bower.json'],
+    tasks: ['wiredep']
+  },
+  js: {
+    files: [
+      '<%= path.app %>/scripts/**/*.js',
+      '<%= path.app %>/components/**/*.js'
+    ],
+    tasks: ['newer:jshint:all', 'newer:jscs'],
+    options: {
+      livereload: '<%= options.livereload %>'
+    }
+  },
+  jsTest: {
+    files: ['test/unit/**/*.js'],
+    tasks: ['newer:jshint:test', 'newer:jscs', 'karma']
+  },
+  compass: {
+    files: ['<%= path.app %>/styles/**/*.{scss,sass}'],
+    tasks: ['compass:server', 'autoprefixer:server']
+  },
+  gruntfile: {
+    files: ['Gruntfile.js']
+  },
+  livereload: {
+    options: {
+      livereload: '<%= options.livereload %>'
+    },
+    files: [
+      '<%= path.app %>/**/*.html',
+      '.tmp/styles/**/*.css',
+      '<%= path.app %>/images/**/*.{png,jpg,jpeg,gif,webp,svg}'
+    ]
+  }
+}

--- a/grunt/wiredep.js
+++ b/grunt/wiredep.js
@@ -1,0 +1,26 @@
+module.exports = {
+  app: {
+    src: ['<%= path.app %>/index.html'],
+    ignorePath:  /\.\.\//
+  },
+  test: {
+    devDependencies: true,
+    src: '<%= path.karmaConf %>',
+    ignorePath:  /\.\.\//,
+      fileTypes:{
+        js: {
+          block: /(([\s\t]*)\/{2}\s*?bower:\s*?(\S*))(\n|\r|.)*?(\/{2}\s*endbower)/gi,
+          detect: {
+            js: /'(.*\.js)'/gi
+          },
+          replace: {
+            js: '\'{{filePath}}\','
+          }
+        }
+      }
+  },
+  sass: {
+    src: ['<%= path.app %>/styles/**/*.{scss,sass}'],
+    ignorePath: /(\.\.\/){1,2}bower_components\//
+  }
+}

--- a/package.json
+++ b/package.json
@@ -34,14 +34,15 @@
     "grunt-version-check": "^0.2.1",
     "grunt-wiredep": "^2.0.0",
     "gzippo": "^0.2.0",
-    "jit-grunt": "^0.9.1",
     "jscoverage": "~0.5.9",
     "jshint-stylish": "^2.0.1",
     "karma-chrome-launcher": "^0.2.0",
     "karma-coverage": "^0.4.2",
     "karma-jasmine": "^0.3.6",
+    "grunt-jsdoc": "^1.1.0",
     "karma-ng-html2js-preprocessor": "^0.1.2",
     "karma-phantomjs-launcher": "*",
+    "load-grunt-config": "^0.19.1",
     "morgan": "^1.6.1",
     "time-grunt": "^1.0.0"
   },
@@ -55,7 +56,6 @@
   },
   "devDependencies": {
     "codacy-coverage": "^1.1.3",
-    "grunt-jsdoc": "^1.1.0",
     "grunt-protractor-runner": "^3.0.0",
     "ink-docstrap": "^1.0.2"
   }


### PR DESCRIPTION
**Problem**
The grunt file is quiet large (~600 lines) which make it difficult to
understand an debug.

**Solution**
* Abstract every task configuration in `grunt/`
* Create `grunt/aliases.js` to store tasks

**Result**
Gruntfile contains less than 100 lines