### PR TITLE
Revert ":green_heart: Add heroku deployment"

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: npm start


### PR DESCRIPTION
Reverts 10alab/Siurana#40

**Problem**
Heroku does not need a Procfile with `npm start` as it is the default

**Solution**
:fire: Remove unnecessary `Procfile`