### PR TITLE
Improve route redirection when not authenticated

### DIFF
--- a/app/components/core/core.module.js
+++ b/app/components/core/core.module.js
@@ -14,5 +14,6 @@
   .config(['$httpProvider', function($httpProvider) {
     $httpProvider.interceptors.push('authInterceptor')
   }])
+
 // jscs:disable disallowSemicolons
 })();

--- a/app/components/core/core.run.js
+++ b/app/components/core/core.run.js
@@ -1,0 +1,25 @@
+(function() {
+  'use strict'
+
+  /**
+  * @module climbingMemoCore
+  * @name climbingMemoCore.app:Run
+  * @description
+  * Run function to handle routes events
+  */
+  angular.module('climbingMemo.core')
+  .run(routesEventsRun)
+
+  routesEventsRun.$inject = ['$rootScope', '$location', 'Auth']
+
+  function routesEventsRun($rootScope, $location, Auth) {
+    $rootScope.$on('$routeChangeStart', function(event) {
+      if (!Auth.isLoggedIn() &&
+          $location.url() !== '/') {
+        event.preventDefault()
+        $location.path('/')
+      }
+    })
+  }
+// jscs:disable disallowSemicolons
+})();

--- a/app/components/core/services/authInterceptor.service.js
+++ b/app/components/core/services/authInterceptor.service.js
@@ -21,6 +21,12 @@
   function authInterceptorService($q, $location, Auth, APP_CONFIG) {
     var authInterceptor = {}
 
+    /**
+    * Intercept http request and add auth token
+    *
+    * @param {Object} request
+    * @returns {Object} request
+    */
     authInterceptor.request = function(request) {
       if (request.url.indexOf(APP_CONFIG.url) === 0 &&
           Auth.getToken()) {
@@ -30,6 +36,13 @@
       return request
     }
 
+    /**
+    * Intercept http error responses and handle unauthorized error code by
+    * redirecting to the home page
+    *
+    * @param {Object} response
+    * @returns {Object} response
+    */
     authInterceptor.responseError = function(response) {
       if (response.status === 401 &&
           $location.url() !== '/') {

--- a/app/components/users/directives/userLogin.js
+++ b/app/components/users/directives/userLogin.js
@@ -12,14 +12,12 @@
   .directive('userLogin', userLoginDirective)
 
   userLoginDirective.$inject = [
-    '$rootScope',
-    '$location',
     'UserLoginSvc',
     'notificationService',
     'Auth'
   ]
 
-  function userLoginDirective($rootScope, $location, UserLoginSvc,
+  function userLoginDirective(UserLoginSvc,
   notificationService, Auth) {
     return {
       restrict: 'E',
@@ -39,11 +37,7 @@
           }
         }
 
-        scope.logOut = function() {
-          Auth.deleteSession()
-          notificationService.success('You are not logged out')
-          $location.path('/')
-        }
+        scope.logOut = UserLoginSvc.logOut
 
         scope.initDirective = function() {
           scope.isLoggedIn = Auth.isLoggedIn

--- a/app/components/users/services/userLogin.service.js
+++ b/app/components/users/services/userLogin.service.js
@@ -22,6 +22,7 @@
   function userLoginService($log, $q, $location, UsersSvc, Auth,
   APP_CONFIG) {
     var UserLogin = {}
+    var firebaseReference = new Firebase(APP_CONFIG.url)
 
     /**
      * Handle successful login from provider
@@ -37,12 +38,22 @@
     }
 
     /**
+    * Remove local session, invalidate the token and redirect to home page
+    *
+    * @method logOut
+    */
+    UserLogin.logOut = function() {
+      Auth.deleteSession()
+      firebaseReference.unauth()
+      $location.path('/')
+    }
+
+    /**
     * Prompt the user to login and then invoke the google login popup
     *
     * @return {Object} promise that resolve to profile info
     */
     UserLogin.googleSignIn = function() {
-      var firebaseReference = new Firebase(APP_CONFIG.url)
       var deferred = $q.defer()
 
       firebaseReference.authWithOAuthPopup('google', function(error, data) {

--- a/app/components/users/users.service.js
+++ b/app/components/users/users.service.js
@@ -37,7 +37,11 @@
     * @return {Object} promise
     */
     Users.getProfile = function(uid) {
-      return $http.get(Users.getUrl(uid + '/profile.json'))
+      return $http({
+        method: 'GET',
+        url: Users.getUrl(uid + '/profile.json'),
+        cache: true
+      })
     }
 
     /**

--- a/app/index.html
+++ b/app/index.html
@@ -80,6 +80,7 @@
     <!-- Angular ClimbingMemo core module -->
     <script src="components/core/core.module.js"></script>
     <script src="components/core/core.config.js"></script>
+    <script src="components/core/core.run.js"></script>
     <script src="components/core/services/auth.service.js"></script>
     <script src="components/core/services/authInterceptor.service.js"></script>
 

--- a/app/scripts/app.routes.js
+++ b/app/scripts/app.routes.js
@@ -18,7 +18,19 @@
   .config(function($routeProvider) {
     $routeProvider
     .when('/', {
-      templateUrl: 'views/home.html'
+      templateUrl: 'views/home.html',
+      resolve: {
+        authentication: function($q, $location, Auth) {
+          var deferred = $q.defer()
+          if (Auth.isLoggedIn()) {
+            deferred.reject()
+            $location.path('/timeline')
+          } else {
+            deferred.resolve()
+          }
+          return deferred.promise
+        }
+      }
     })
     .when('/table', {
       controller: 'tableCtrl',


### PR DESCRIPTION
**Problem**
When user is not logged in and try to access to a route, it will only
redirect after a network queries has been made.

**Solution**
* Add routeChangeStart event to handle auth
* Add token invalidation on log out
* Make timeline as default page when logged in
* Cache profile network request

**Result**
Even is cancelled when trying to access to a route that require
authentication