### PR TITLE
Fix unit-test for overview chart

### DIFF
--- a/app/components/charts/spec/overviewchart.js
+++ b/app/components/charts/spec/overviewchart.js
@@ -34,12 +34,35 @@ describe('Directive: overviewChart', function() {
   })
 
   it('should fill rectangles for each routes day', function() {
-    var year = new Date().getFullYear()
+    var lastMonthDate = new Date(Date.now() - 1000 * 86400 * 30)
+    var year = lastMonthDate.getFullYear()
+    var month = lastMonthDate.getMonth()
+
     var routes = [
-      { "date": "05/12/" + year, "grade": "5.12b", "status": "Flash", "type": "Traditional" },
-      { "date": "07/13/" + year, "grade": "V7", "status": "Redpoint", "type": "Boulder" },
-      { "date": "07/13/" + year, "grade": "V5", "status": "Onsight", "type": "Boulder" },
-      { "date": "07/07/" + year, "grade": "5.9", "status": "Onsight", "type": "Sport lead" }
+      {
+        "date": "05/" + month + "/" + year,
+        "grade": "5.12b",
+        "status": "Flash",
+        "type": "Traditional"
+      },
+      {
+        "date": "07/" + month + "/" + year,
+        "grade": "V7",
+        "status": "Redpoint",
+        "type": "Boulder"
+      },
+      {
+        "date": "07/" + month + "/" + year,
+        "grade": "V5",
+        "status": "Onsight",
+        "type": "Boulder"
+      },
+      {
+        "date": "08/" + month + "/" + year,
+        "grade": "5.9",
+        "status": "Onsight",
+        "type": "Sport lead"
+      }
     ]
     prepareDirective(routes)
 
@@ -52,7 +75,7 @@ describe('Directive: overviewChart', function() {
     prepareDirective(routes)
 
     scope.routes = [
-      { "date": "05/12/" + year, "grade": "5.12b", "status": "Flash", "type": "Traditional" }
+      { "date": "01/01/" + year, "grade": "5.12b", "status": "Flash", "type": "Traditional" }
     ]
     scope.$digest()
 


### PR DESCRIPTION
**Problem**
Build is failing on develop due to a unit-test error on the overview
chart directive

**Solution**
The test is using the current year to display the routes on the chart
which doesn't work when you run the tests at the very beginning of a
year (ex: Jan 2016)

Use the last month as date reference, which will be either current year
or year - 1

**Result**
Unit-test are passing